### PR TITLE
feat(skills): add Claude Agent SDK skill and capabilities documentation

### DIFF
--- a/docs/claude-code-capabilities.md
+++ b/docs/claude-code-capabilities.md
@@ -12,6 +12,8 @@ A comprehensive reference for Claude Code's extensibility features: hooks, agent
 6. [Plugins & Marketplaces](#plugins--marketplaces)
 7. [Claude Agent SDK](#claude-agent-sdk)
 8. [Feature Comparison](#feature-comparison)
+9. [CLI Reference](#cli-reference)
+10. [Interactive Mode](#interactive-mode)
 
 ---
 
@@ -507,10 +509,121 @@ CLAUDE.md                     # Project context
 
 ---
 
+## CLI Reference
+
+### CLI Commands
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `claude` | Start interactive REPL | `claude` |
+| `claude "query"` | Start REPL with initial prompt | `claude "explain this project"` |
+| `claude -p "query"` | Query via SDK, then exit | `claude -p "explain this function"` |
+| `cat file \| claude -p "query"` | Process piped content | `cat logs.txt \| claude -p "explain"` |
+| `claude -c` | Continue most recent conversation | `claude -c` |
+| `claude -r "<id>" "query"` | Resume session by ID | `claude -r "abc123" "Finish PR"` |
+| `claude update` | Update to latest version | `claude update` |
+| `claude mcp` | Configure MCP servers | `claude mcp` |
+
+### CLI Flags
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `--add-dir` | Add additional working directories | `claude --add-dir ../apps ../lib` |
+| `--agents` | Define custom subagents via JSON | See below |
+| `--allowedTools` | Tools allowed without permission | `"Bash(git log:*)" "Read"` |
+| `--disallowedTools` | Tools to block | `"Bash(rm:*)" "Edit"` |
+| `--print`, `-p` | Print mode (non-interactive) | `claude -p "query"` |
+| `--system-prompt` | Replace entire system prompt | `claude --system-prompt "..."` |
+| `--append-system-prompt` | Append to default prompt | `claude --append-system-prompt "..."` |
+| `--output-format` | Output format: `text`, `json`, `stream-json` | `claude -p --output-format json` |
+| `--verbose` | Enable verbose logging | `claude --verbose` |
+| `--max-turns` | Limit agentic turns | `claude -p --max-turns 3` |
+| `--model` | Set model (`sonnet`, `opus`, or full name) | `claude --model opus` |
+| `--permission-mode` | Set permission mode | `claude --permission-mode plan` |
+| `--resume` | Resume session by ID | `claude --resume abc123` |
+| `--continue` | Load most recent conversation | `claude --continue` |
+| `--dangerously-skip-permissions` | Skip permission prompts | Use with caution |
+
+### Dynamic Agents via CLI
+
+```bash
+claude --agents '{
+  "code-reviewer": {
+    "description": "Expert code reviewer. Use proactively after code changes.",
+    "prompt": "You are a senior code reviewer. Focus on quality and security.",
+    "tools": ["Read", "Grep", "Glob", "Bash"],
+    "model": "sonnet"
+  }
+}'
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `description` | Yes | When the subagent should be invoked |
+| `prompt` | Yes | System prompt for the subagent |
+| `tools` | No | Array of tools (inherits all if omitted) |
+| `model` | No | `sonnet`, `opus`, or `haiku` |
+
+### System Prompt Flags
+
+| Flag | Behavior | Modes |
+|------|----------|-------|
+| `--system-prompt` | **Replaces** entire prompt | Interactive + Print |
+| `--system-prompt-file` | **Replaces** with file contents | Print only |
+| `--append-system-prompt` | **Appends** to default prompt | Interactive + Print |
+
+---
+
+## Interactive Mode
+
+### Keyboard Shortcuts
+
+| Shortcut | Description |
+|----------|-------------|
+| `Ctrl+C` | Cancel current input/generation |
+| `Ctrl+D` | Exit Claude Code session |
+| `Ctrl+L` | Clear terminal screen |
+| `Ctrl+O` | Toggle verbose output |
+| `Ctrl+R` | Reverse search command history |
+| `Ctrl+V` / `Alt+V` | Paste image from clipboard |
+| `Up/Down` | Navigate command history |
+| `Esc` + `Esc` | Rewind code/conversation |
+| `Tab` | Toggle extended thinking |
+| `Shift+Tab` | Toggle permission modes |
+
+### Quick Commands
+
+| Shortcut | Description |
+|----------|-------------|
+| `#` at start | Add memory to CLAUDE.md |
+| `/` at start | Slash command |
+| `!` at start | Bash mode (run directly) |
+| `@` | File path autocomplete |
+
+### Multiline Input
+
+| Method | Shortcut |
+|--------|----------|
+| Quick escape | `\` + `Enter` |
+| macOS | `Option+Enter` |
+| After `/terminal-setup` | `Shift+Enter` |
+| Control sequence | `Ctrl+J` |
+
+### Background Commands
+
+Run commands in the background while continuing to work:
+- Press `Ctrl+B` to background a running command
+- Claude can retrieve output later with `BashOutput` tool
+- Useful for dev servers, builds, test runners
+
+---
+
 ## Resources
 
 ### Official Documentation
 - [Claude Code Overview](https://docs.anthropic.com/en/docs/claude-code/overview)
+- [CLI Reference](https://docs.anthropic.com/en/docs/claude-code/cli-reference)
+- [Interactive Mode](https://docs.anthropic.com/en/docs/claude-code/interactive-mode)
 - [Hooks Reference](https://docs.anthropic.com/en/docs/claude-code/hooks)
 - [Skills Guide](https://www.anthropic.com/news/skills)
 - [Plugins Guide](https://www.anthropic.com/news/claude-code-plugins)

--- a/docs/claude-code-capabilities.md
+++ b/docs/claude-code-capabilities.md
@@ -1,0 +1,521 @@
+# Claude Code Capabilities Guide
+
+A comprehensive reference for Claude Code's extensibility features: hooks, agents, skills, commands, plugins, and the Agent SDK.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Hooks](#hooks)
+3. [Subagents](#subagents)
+4. [Skills](#skills)
+5. [Slash Commands](#slash-commands)
+6. [Plugins & Marketplaces](#plugins--marketplaces)
+7. [Claude Agent SDK](#claude-agent-sdk)
+8. [Feature Comparison](#feature-comparison)
+
+---
+
+## Overview
+
+Claude Code provides multiple extensibility mechanisms:
+
+| Feature | Purpose | Invocation | Location |
+|---------|---------|------------|----------|
+| **Hooks** | Automate actions at lifecycle events | Automatic | `settings.json` |
+| **Subagents** | Specialized AI assistants | Claude-delegated | `.claude/agents/` |
+| **Skills** | Domain expertise modules | Auto-detected | `.claude/skills/` |
+| **Commands** | User-triggered shortcuts | `/command` | `.claude/commands/` |
+| **Plugins** | Bundled extensions | `/plugin install` | Marketplace |
+| **SDK** | Programmatic API | Code | npm/pip |
+
+---
+
+## Hooks
+
+Hooks execute shell commands at specific lifecycle events, enabling workflow automation without manual intervention.
+
+### Hook Events
+
+| Event | Trigger | Use Cases |
+|-------|---------|-----------|
+| `SessionStart` | Claude Code starts | Install dependencies, set env vars |
+| `SessionEnd` | Session terminates | Cleanup, save state |
+| `UserPromptSubmit` | User submits prompt | Validate input, pre-process |
+| `PreToolUse` | Before tool execution | Validate, set up logging |
+| `PostToolUse` | After tool completes | Process results, update state |
+| `Stop` | Claude finishes responding | Save session, archive changes |
+| `PreCompact` | Before context compaction | Preserve important context |
+| `SubagentStop` | Subagent finishes | Coordinate results |
+
+### Configuration
+
+```json
+{
+  "hooks": {
+    "SessionStart": [{
+      "hooks": [{
+        "type": "command",
+        "command": "./scripts/setup.sh",
+        "timeout": 120,
+        "statusMessage": "Setting up environment..."
+      }]
+    }],
+    "PreToolUse": [{
+      "matcher": "Bash",
+      "hooks": [{
+        "type": "command",
+        "command": "./scripts/validate-bash.sh"
+      }]
+    }]
+  }
+}
+```
+
+### Hook Options
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `matcher` | string | Pattern to match (for PreToolUse/PostToolUse) |
+| `type` | string | `"command"` or `"prompt"` |
+| `command` | string | Shell command or script path |
+| `timeout` | number | Max execution time in seconds (default: 60) |
+| `statusMessage` | string | Display message during execution |
+| `continue` | boolean | Whether to continue after hook (default: true) |
+| `stopReason` | string | Message when `continue` is false |
+
+### Exit Codes
+
+- **0**: Success
+- **2**: Blocking error (stderr fed to Claude)
+- **Other**: Non-blocking error (shown to user)
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `$CLAUDE_PROJECT_DIR` | Project root directory |
+| `$CLAUDE_PLUGIN_ROOT` | Plugin installation directory |
+| `$CLAUDE_ENV_FILE` | Path to session env file |
+| `$CLAUDE_CODE_REMOTE` | `"true"` if running in cloud |
+
+---
+
+## Subagents
+
+Subagents are specialized AI assistants that Claude delegates tasks to based on the task type and complexity.
+
+### File Structure
+
+```markdown
+---
+name: code-reviewer
+description: Specialized agent for thorough code reviews
+tools: Read, Grep, Bash
+model: sonnet
+permissionMode: default
+skills: security-review
+---
+
+You are an expert code reviewer specializing in:
+- Security vulnerabilities
+- Performance optimization
+- Code maintainability
+
+When reviewing code:
+1. Check for security issues first
+2. Analyze performance implications
+3. Suggest specific improvements
+```
+
+### Configuration Options
+
+| Field | Description |
+|-------|-------------|
+| `name` | Unique identifier |
+| `description` | When to invoke this agent |
+| `tools` | Comma-separated tool list |
+| `model` | `sonnet`, `opus`, `haiku`, or `inherit` |
+| `permissionMode` | `default`, `acceptEdits`, `bypassPermissions`, `plan` |
+| `skills` | Skills to auto-load |
+
+### Locations
+
+- **User agents**: `~/.claude/agents/` (all projects)
+- **Project agents**: `.claude/agents/` (team-shared)
+- **Plugin agents**: `plugins/{name}/agents/`
+
+---
+
+## Skills
+
+Skills are modular directories containing instructions and resources that Claude loads dynamically for specialized tasks.
+
+### Directory Structure
+
+```
+skills/my-skill/
+├── SKILL.md              # Required: Core definition
+├── README.md             # Optional: Documentation
+├── reference.md          # Optional: Detailed specs
+├── resources/            # Optional: Reference files
+│   ├── config.json
+│   └── templates/
+└── scripts/              # Optional: Helper scripts
+    └── validate.py
+```
+
+### SKILL.md Format
+
+```markdown
+---
+name: api-design
+description: REST API design and review based on best practices
+---
+
+# API Design Skill
+
+## When to Use This Skill
+- Designing new REST APIs
+- Reviewing API specifications
+- Validating OpenAPI documents
+
+## Core Principles
+- Resource-oriented design
+- Standard HTTP methods
+- Consistent naming conventions
+
+## Resources
+- [Error codes reference](./resources/error-codes.json)
+- [OpenAPI template](./resources/openapi-template.yaml)
+```
+
+### Progressive Loading
+
+1. **Level 1 (Always)**: Name and description for discovery
+2. **Level 2 (On relevance)**: Main SKILL.md body
+3. **Level 3+ (On demand)**: Additional files and resources
+
+### Locations
+
+- **User skills**: `~/.claude/skills/`
+- **Project skills**: `.claude/skills/`
+- **Plugin skills**: `plugins/{name}/skills/`
+
+---
+
+## Slash Commands
+
+Slash commands are user-triggered shortcuts for frequently-used operations.
+
+### File Format
+
+```markdown
+---
+description: Comprehensive code quality review
+category: review
+argument-hint: <file or directory>
+allowed-tools: Read, Grep, Bash
+disable-model-invocation: true
+model: claude-sonnet-4-5-20250929
+---
+
+# Code Review Command
+
+Perform a thorough code review of the specified target.
+
+## Instructions
+1. Analyze code structure
+2. Check for code smells
+3. Review security implications
+4. Suggest improvements
+
+## Arguments
+$ARGUMENTS - The file or directory to review
+```
+
+### Frontmatter Options
+
+| Field | Description |
+|-------|-------------|
+| `description` | Shown in `/help` |
+| `category` | Logical grouping |
+| `argument-hint` | Shows expected arguments |
+| `allowed-tools` | Restricts available tools |
+| `disable-model-invocation` | Prevents auto-invocation |
+| `model` | Specific model to use |
+
+### Built-in Commands
+
+- `/help` - Show available commands
+- `/context` - Display context info
+- `/usage` - Show token usage
+- `/model` - View/change model
+- `/compact` - Compact conversation
+- `/plugin` - Manage plugins
+- `/permissions` - Manage permissions
+- `/hooks` - Review hook changes
+
+### Locations
+
+- **User commands**: `~/.claude/commands/`
+- **Project commands**: `.claude/commands/`
+- **Plugin commands**: `plugins/{name}/commands/`
+
+---
+
+## Plugins & Marketplaces
+
+Plugins bundle commands, agents, skills, hooks, and MCP servers for easy distribution.
+
+### Plugin Structure
+
+```
+my-plugin/
+├── .claude-plugin/
+│   └── plugin.json          # Required: Manifest
+├── commands/                # Slash commands
+├── agents/                  # Subagents
+├── skills/                  # Skills
+├── hooks/
+│   ├── hooks.json           # Hook configuration
+│   └── scripts/
+└── .mcp.json                # MCP servers
+```
+
+### plugin.json
+
+```json
+{
+  "name": "my-plugin",
+  "displayName": "My Plugin",
+  "description": "Plugin description",
+  "version": "1.0.0",
+  "author": "Your Name",
+  "commands": "./commands",
+  "agents": "./agents",
+  "skills": "./skills",
+  "hooks": "./hooks/hooks.json",
+  "mcp": "./.mcp.json"
+}
+```
+
+### Marketplace Configuration
+
+```json
+{
+  "name": "my-marketplace",
+  "metadata": {
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "plugin-name",
+      "source": "./plugins/plugin-name",
+      "description": "Plugin description",
+      "category": "productivity",
+      "tags": ["tag1", "tag2"]
+    }
+  ]
+}
+```
+
+### Installing Plugins
+
+```bash
+# Add marketplace
+/plugin marketplace add https://github.com/org/marketplace
+
+# Install plugin
+/plugin install plugin-name@marketplace-name
+
+# List installed
+/plugin list
+```
+
+### Settings Configuration
+
+```json
+{
+  "enabledPlugins": {
+    "plugin@marketplace": true
+  },
+  "extraKnownMarketplaces": {
+    "team-tools": {
+      "source": { "source": "github", "repo": "org/plugins" }
+    }
+  }
+}
+```
+
+---
+
+## Claude Agent SDK
+
+The Claude Agent SDK provides programmatic access to Claude Code's capabilities.
+
+### Installation
+
+```bash
+# Python
+pip install claude-agent-sdk
+
+# TypeScript
+npm install @anthropic-ai/claude-agent-sdk
+```
+
+### Python Example
+
+```python
+import anyio
+from claude_agent_sdk import query, ClaudeAgentOptions
+
+async def main():
+    options = ClaudeAgentOptions(
+        system_prompt="You are a helpful assistant",
+        allowed_tools=["Read", "Write", "Bash"],
+        permission_mode="acceptEdits",
+        cwd="/path/to/project"
+    )
+
+    async for message in query(prompt="Create a hello world script", options=options):
+        if message.type == "assistant":
+            for block in message.content:
+                if block.type == "text":
+                    print(block.text)
+
+anyio.run(main)
+```
+
+### TypeScript Example
+
+```typescript
+import { query, type ClaudeAgentOptions } from '@anthropic-ai/claude-agent-sdk';
+
+async function main() {
+    const options: ClaudeAgentOptions = {
+        systemPrompt: "You are a helpful assistant",
+        allowedTools: ["Read", "Write", "Bash"],
+        permissionMode: "acceptEdits",
+        cwd: "/path/to/project"
+    };
+
+    for await (const message of query({ prompt: "Create a hello world script", options })) {
+        if (message.type === "assistant") {
+            for (const block of message.message.content) {
+                if (block.type === "text") {
+                    console.log(block.text);
+                }
+            }
+        }
+    }
+}
+```
+
+### Key Options
+
+| Option | Description |
+|--------|-------------|
+| `system_prompt` | Custom system instructions |
+| `allowed_tools` | Tool whitelist |
+| `permission_mode` | `"acceptEdits"` or `"manual"` |
+| `cwd` | Working directory |
+| `max_turns` | Conversation limit |
+| `mcp_servers` | Custom MCP servers |
+| `setting_sources` | Load project config |
+
+### Custom Tools
+
+```python
+from claude_agent_sdk import tool, create_sdk_mcp_server
+
+@tool("get_weather", "Get weather for a location", {"location": str})
+async def get_weather(args):
+    return {"content": [{"type": "text", "text": f"Sunny in {args['location']}"}]}
+
+server = create_sdk_mcp_server(name="my-tools", tools=[get_weather])
+```
+
+---
+
+## Feature Comparison
+
+### Invocation Methods
+
+| Feature | User-Invoked | Auto-Invoked | Claude-Delegated |
+|---------|--------------|--------------|------------------|
+| Hooks | - | ✓ | - |
+| Skills | - | ✓ | - |
+| Commands | ✓ | Optional | - |
+| Subagents | - | - | ✓ |
+| Plugins | ✓ (install) | - | - |
+
+### Configuration Locations
+
+| Feature | User Level | Project Level | Plugin |
+|---------|------------|---------------|--------|
+| Hooks | `~/.claude/settings.json` | `.claude/settings.json` | `hooks.json` |
+| Skills | `~/.claude/skills/` | `.claude/skills/` | `skills/` |
+| Commands | `~/.claude/commands/` | `.claude/commands/` | `commands/` |
+| Agents | `~/.claude/agents/` | `.claude/agents/` | `agents/` |
+
+### Claude Code CLI vs SDK
+
+| Feature | CLI | SDK |
+|---------|-----|-----|
+| Interactive REPL | ✓ | - |
+| IDE Integration | ✓ | - |
+| Plugins | ✓ | - |
+| Sandbox Mode | ✓ | - |
+| In-Process MCP | - | ✓ |
+| Session Forking | - | ✓ |
+| Runtime Tool Filtering | - | ✓ |
+| Multi-Agent Orchestration | Limited | Full |
+
+---
+
+## Quick Reference
+
+### File Locations
+
+```
+~/.claude/                    # User-level config
+├── settings.json             # User settings
+├── agents/                   # User agents
+├── commands/                 # User commands
+└── skills/                   # User skills
+
+.claude/                      # Project-level config
+├── settings.json             # Shared settings
+├── settings.local.json       # Local overrides
+├── agents/                   # Project agents
+├── commands/                 # Project commands
+└── skills/                   # Project skills
+
+CLAUDE.md                     # Project context
+.mcp.json                     # MCP servers
+```
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `ANTHROPIC_API_KEY` | API authentication |
+| `ANTHROPIC_MODEL` | Model selection |
+| `CLAUDE_CODE_USE_BEDROCK` | Enable Bedrock |
+| `CLAUDE_CODE_USE_VERTEX` | Enable Vertex AI |
+| `MAX_THINKING_TOKENS` | Extended thinking budget |
+
+---
+
+## Resources
+
+### Official Documentation
+- [Claude Code Overview](https://docs.anthropic.com/en/docs/claude-code/overview)
+- [Hooks Reference](https://docs.anthropic.com/en/docs/claude-code/hooks)
+- [Skills Guide](https://www.anthropic.com/news/skills)
+- [Plugins Guide](https://www.anthropic.com/news/claude-code-plugins)
+- [Agent SDK Overview](https://docs.claude.com/en/api/agent-sdk/overview)
+
+### GitHub Repositories
+- [Python SDK](https://github.com/anthropics/claude-agent-sdk-python)
+- [TypeScript SDK](https://github.com/anthropics/claude-agent-sdk-typescript)

--- a/registry/skills/claude-agent-sdk/README.md
+++ b/registry/skills/claude-agent-sdk/README.md
@@ -1,0 +1,57 @@
+# Claude Agent SDK Skill
+
+A comprehensive skill for building AI agents with the Claude Agent SDK in both TypeScript and Python.
+
+## Overview
+
+This skill provides:
+- Complete API reference for both Python and TypeScript SDKs
+- Feature parity comparison between Claude Code CLI and SDK
+- Working code examples for common patterns
+- Best practices for agent development
+
+## Contents
+
+- **SKILL.md** - Main skill documentation with API reference
+- **resources/feature-parity.md** - Detailed comparison between CLI and SDK
+- **examples/** - Working code examples:
+  - `quick_start.py` - Basic Python usage
+  - `multi_turn.py` - Multi-turn conversations in Python
+  - `custom_tools.py` - Custom MCP tools in Python
+  - `quick_start.ts` - Basic TypeScript usage
+  - `custom_tools.ts` - Custom MCP tools in TypeScript
+
+## Quick Start
+
+### Python
+
+```bash
+pip install claude-agent-sdk
+```
+
+```python
+from claude_agent_sdk import query
+
+async for message in query(prompt="Hello, Claude!"):
+    print(message)
+```
+
+### TypeScript
+
+```bash
+npm install @anthropic-ai/claude-agent-sdk
+```
+
+```typescript
+import { query } from '@anthropic-ai/claude-agent-sdk';
+
+for await (const message of query({ prompt: "Hello, Claude!" })) {
+    console.log(message);
+}
+```
+
+## Official Resources
+
+- [SDK Overview](https://docs.claude.com/en/api/agent-sdk/overview)
+- [Python SDK GitHub](https://github.com/anthropics/claude-agent-sdk-python)
+- [TypeScript SDK GitHub](https://github.com/anthropics/claude-agent-sdk-typescript)

--- a/registry/skills/claude-agent-sdk/SKILL.md
+++ b/registry/skills/claude-agent-sdk/SKILL.md
@@ -1,0 +1,596 @@
+---
+name: claude-agent-sdk
+description: Comprehensive guide for building AI agents with the Claude Agent SDK in TypeScript and Python, including feature parity with Claude Code CLI.
+---
+
+# Claude Agent SDK Development Guide
+
+## Overview
+
+The **Claude Agent SDK** is a programmatic library that enables developers to build AI agents with Claude Code's capabilities. It provides the same agent harness that powers Claude Code itself, allowing you to create autonomous agents that can understand codebases, edit files, run commands, and execute complex workflows.
+
+## When to Use This Skill
+
+- Building programmatic AI agents with Claude capabilities
+- Creating CLI tools or backend services powered by Claude
+- Integrating Claude Code functionality into applications
+- Developing custom tools with MCP (Model Context Protocol)
+- Understanding feature parity between Claude Code CLI and SDK
+
+---
+
+## Installation
+
+### Python
+
+```bash
+pip install claude-agent-sdk
+```
+
+**Requirements:** Python 3.10+
+
+### TypeScript/Node.js
+
+```bash
+npm install @anthropic-ai/claude-agent-sdk
+```
+
+**Requirements:** Node.js 18+
+
+---
+
+## Authentication
+
+Set your API key as an environment variable:
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+```
+
+### Alternative Providers
+
+```bash
+# Amazon Bedrock
+export CLAUDE_CODE_USE_BEDROCK=1
+
+# Google Vertex AI
+export CLAUDE_CODE_USE_VERTEX=1
+
+# Microsoft Foundry
+export CLAUDE_CODE_USE_FOUNDRY=1
+```
+
+---
+
+## Core API Reference
+
+### Python SDK
+
+#### `query()` Function
+
+Simple async interface for stateless queries:
+
+```python
+import anyio
+from claude_agent_sdk import query, ClaudeAgentOptions, AssistantMessage, TextBlock
+
+async def main():
+    options = ClaudeAgentOptions(
+        system_prompt="You are a helpful coding assistant",
+        allowed_tools=["Read", "Write", "Bash"],
+        permission_mode="acceptEdits",
+        cwd="/path/to/project"
+    )
+
+    async for message in query(prompt="Create a hello world script", options=options):
+        if isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, TextBlock):
+                    print(block.text)
+
+anyio.run(main)
+```
+
+#### `ClaudeSDKClient` Class
+
+Bidirectional, stateful client for multi-turn conversations:
+
+```python
+from claude_agent_sdk import ClaudeSDKClient, ClaudeAgentOptions
+
+async def main():
+    options = ClaudeAgentOptions(
+        system_prompt="You are a code reviewer",
+        allowed_tools=["Read", "Grep", "Bash"],
+        permission_mode="acceptEdits"
+    )
+
+    async with ClaudeSDKClient(options=options) as client:
+        # First turn
+        await client.query("Review the auth module")
+        async for message in client.receive_messages():
+            if message.type == "result":
+                break
+
+        # Second turn - context preserved
+        await client.query("Now check for security issues")
+        async for message in client.receive_messages():
+            if message.type == "result":
+                break
+```
+
+### TypeScript SDK
+
+#### `query()` Function
+
+```typescript
+import { query, type ClaudeAgentOptions } from '@anthropic-ai/claude-agent-sdk';
+
+async function main() {
+    const options: ClaudeAgentOptions = {
+        systemPrompt: "You are a TypeScript expert",
+        allowedTools: ["Read", "Write", "Bash"],
+        permissionMode: "acceptEdits",
+        cwd: "/path/to/project"
+    };
+
+    const stream = query({ prompt: "Create an Express server", options });
+
+    for await (const message of stream) {
+        if (message.type === "assistant") {
+            for (const block of message.message.content) {
+                if (block.type === "text") {
+                    console.log(block.text);
+                }
+            }
+        }
+    }
+}
+```
+
+#### `ClaudeSDKClient` Class
+
+```typescript
+import { ClaudeSDKClient, type ClaudeAgentOptions } from '@anthropic-ai/claude-agent-sdk';
+
+async function main() {
+    const options: ClaudeAgentOptions = {
+        systemPrompt: "You are a full-stack developer",
+        allowedTools: ["Read", "Write", "Bash", "Grep"],
+        permissionMode: "acceptEdits"
+    };
+
+    const client = new ClaudeSDKClient(options);
+    await client.connect();
+
+    try {
+        await client.query("Create a REST API endpoint");
+        for await (const msg of client.receiveMessages()) {
+            if (msg.type === "result") break;
+            console.log(msg);
+        }
+    } finally {
+        await client.disconnect();
+    }
+}
+```
+
+---
+
+## ClaudeAgentOptions Reference
+
+### Python Options
+
+```python
+from claude_agent_sdk import ClaudeAgentOptions
+
+options = ClaudeAgentOptions(
+    # System prompt for the agent
+    system_prompt="You are a helpful assistant",
+
+    # Tool access control
+    allowed_tools=["Read", "Write", "Bash", "Grep", "Glob"],
+
+    # Permission mode: "acceptEdits" auto-accepts file changes
+    permission_mode="acceptEdits",
+
+    # Working directory
+    cwd="/path/to/project",
+
+    # Maximum conversation turns
+    max_turns=10,
+
+    # Session management
+    resume_session="session-id",  # Resume existing session
+    fork_session=True,            # Fork from session
+
+    # Load project settings (.claude/settings.json, CLAUDE.md, etc.)
+    setting_sources=["project", "local"],
+
+    # MCP servers for custom tools
+    mcp_servers=[mcp_server_instance],
+
+    # Custom tool filtering
+    can_use_tool=lambda name: name != "Bash",
+
+    # Hooks for workflow automation
+    hooks={
+        "PreToolUse": [hook_config],
+        "PostToolUse": [hook_config]
+    },
+
+    # Custom CLI path (optional)
+    cli_path="/custom/path/to/claude"
+)
+```
+
+### TypeScript Options
+
+```typescript
+interface ClaudeAgentOptions {
+    systemPrompt?: string;
+    allowedTools?: string[];
+    disallowedTools?: string[];
+    permissionMode?: "acceptEdits" | "manual";
+    cwd?: string;
+    maxTurns?: number;
+    resumeSession?: string;
+    forkSession?: boolean;
+    settingSources?: string[];
+    mcpServers?: MCP[];
+    canUseTool?: (toolName: string) => boolean;
+}
+```
+
+---
+
+## Available Tools
+
+The SDK provides access to Claude Code's built-in tools:
+
+| Tool | Description | Permission |
+|------|-------------|------------|
+| `Read` | Read file contents | No |
+| `Write` | Create/overwrite files | Yes |
+| `Edit` | Make targeted edits | Yes |
+| `Bash` | Execute shell commands | Yes |
+| `Grep` | Search file contents | No |
+| `Glob` | Pattern-based file matching | No |
+| `WebFetch` | Fetch web content | Yes |
+| `WebSearch` | Search the web | Yes |
+| `Task` | Run sub-agents | No |
+| `NotebookEdit` | Modify Jupyter notebooks | Yes |
+
+---
+
+## Custom Tools with MCP
+
+### Python In-Process MCP Server
+
+```python
+from claude_agent_sdk import tool, create_sdk_mcp_server, ClaudeAgentOptions
+
+@tool("get_weather", "Get weather for a location", {"location": str})
+async def get_weather(args):
+    location = args["location"]
+    # Your implementation here
+    return {"content": [{"type": "text", "text": f"Sunny in {location}, 72°F"}]}
+
+@tool("save_note", "Save a note", {"title": str, "content": str})
+async def save_note(args):
+    # Your implementation
+    return {"content": [{"type": "text", "text": f"Note '{args['title']}' saved"}]}
+
+# Create MCP server
+server = create_sdk_mcp_server(
+    name="my-tools",
+    version="1.0.0",
+    tools=[get_weather, save_note]
+)
+
+# Use in options
+options = ClaudeAgentOptions(
+    allowed_tools=[
+        "Read", "Write",
+        "mcp__my-tools__get_weather",
+        "mcp__my-tools__save_note"
+    ],
+    mcp_servers=[server]
+)
+```
+
+### TypeScript Custom Tools
+
+```typescript
+import { createSdkMcpServer, tool, type ClaudeAgentOptions } from '@anthropic-ai/claude-agent-sdk';
+
+const weatherTool = tool({
+    name: "get_weather",
+    description: "Get weather for a location",
+    inputSchema: {
+        type: "object",
+        properties: {
+            location: { type: "string", description: "City name" }
+        },
+        required: ["location"]
+    },
+    execute: async (input: { location: string }) => {
+        return `Weather in ${input.location}: Sunny, 72°F`;
+    }
+});
+
+const mcp = createSdkMcpServer({
+    name: "my-tools",
+    tools: [weatherTool]
+});
+
+const options: ClaudeAgentOptions = {
+    mcpServers: [mcp],
+    allowedTools: ["Read", "Write", "mcp__my-tools__get_weather"]
+};
+```
+
+### External MCP Servers
+
+Configure in `.mcp.json`:
+
+```json
+{
+    "mcpServers": {
+        "github": {
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/server-github"],
+            "env": {
+                "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+            }
+        },
+        "postgres": {
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/server-postgres"],
+            "env": {
+                "POSTGRES_URL": "${DATABASE_URL}"
+            }
+        }
+    }
+}
+```
+
+---
+
+## Session Management
+
+### Resuming Sessions
+
+```python
+# Get session ID from first interaction
+async with ClaudeSDKClient() as client:
+    await client.query("Start a project")
+    session_id = await client.get_session_id()
+
+# Later: resume the session
+async with ClaudeSDKClient() as client:
+    await client.query(
+        "Continue where we left off",
+        resume_session=session_id
+    )
+```
+
+### Forking Sessions
+
+```python
+# Create a branch from existing conversation
+async with ClaudeSDKClient() as client:
+    await client.query(
+        "Try an alternative approach",
+        resume_session=session_id,
+        fork_session=True  # Creates new branch
+    )
+```
+
+---
+
+## Message Types
+
+### Python
+
+```python
+from claude_agent_sdk import (
+    AssistantMessage,
+    UserMessage,
+    SystemMessage,
+    ResultMessage,
+    TextBlock,
+    ToolUseBlock,
+    ToolResultBlock
+)
+
+async for message in query(prompt="Hello"):
+    if isinstance(message, AssistantMessage):
+        for block in message.content:
+            if isinstance(block, TextBlock):
+                print("Text:", block.text)
+            elif isinstance(block, ToolUseBlock):
+                print("Tool:", block.name)
+    elif isinstance(message, ResultMessage):
+        print("Done:", message.subtype)
+```
+
+### TypeScript
+
+```typescript
+for await (const message of stream) {
+    switch (message.type) {
+        case "assistant":
+            for (const block of message.message.content) {
+                if (block.type === "text") {
+                    console.log("Text:", block.text);
+                } else if (block.type === "tool_use") {
+                    console.log("Tool:", block.name);
+                }
+            }
+            break;
+        case "result":
+            console.log("Done:", message.subtype);
+            break;
+    }
+}
+```
+
+---
+
+## Error Handling
+
+### Python
+
+```python
+from claude_agent_sdk import (
+    CLINotFoundError,
+    ProcessError,
+    CLIJSONDecodeError,
+    CLIConnectionError
+)
+
+try:
+    async for message in query(prompt="Hello"):
+        print(message)
+except CLINotFoundError:
+    print("Claude CLI not installed")
+except ProcessError as e:
+    print(f"Process failed: {e}")
+except CLIJSONDecodeError:
+    print("Failed to parse response")
+except CLIConnectionError:
+    print("Connection failed")
+```
+
+---
+
+## Loading Project Configuration
+
+To load `.claude/settings.json`, `CLAUDE.md`, skills, and commands from your project:
+
+### Python
+
+```python
+options = ClaudeAgentOptions(
+    setting_sources=["project", "local"]
+)
+```
+
+### TypeScript
+
+```typescript
+const options: ClaudeAgentOptions = {
+    settingSources: ["project", "local"]
+};
+```
+
+This automatically loads:
+- `.claude/settings.json` - Project settings
+- `.claude/settings.local.json` - Local overrides
+- `CLAUDE.md` or `.claude/CLAUDE.md` - Project context
+- `.claude/skills/` - Custom skills
+- `.claude/agents/` - Custom subagents
+- `.claude/commands/` - Custom slash commands
+
+---
+
+## Feature Parity: Claude Code CLI vs SDK
+
+See [resources/feature-parity.md](./resources/feature-parity.md) for the complete comparison table.
+
+### Quick Reference
+
+| Feature | Claude Code CLI | SDK |
+|---------|----------------|-----|
+| Interactive REPL | Yes | No |
+| Slash Commands | `/command` | Load via `settingSources` |
+| Skills | Auto-loaded | Load via `settingSources` |
+| Subagents | Auto-loaded | Load via `settingSources` |
+| Hooks | settings.json | `hooks` option |
+| MCP Servers | .mcp.json | `mcpServers` option |
+| Plugins | `/plugin` command | Not directly supported |
+| Permissions | `/permissions` | `allowedTools`, `canUseTool` |
+| Sessions | Automatic | `resumeSession`, `forkSession` |
+| IDE Integration | VS Code, JetBrains | Programmatic only |
+
+---
+
+## Best Practices
+
+### 1. Use Appropriate Permission Modes
+
+```python
+# For automated pipelines - auto-accept edits
+options = ClaudeAgentOptions(permission_mode="acceptEdits")
+
+# For interactive apps - manual approval
+options = ClaudeAgentOptions(permission_mode="manual")
+```
+
+### 2. Limit Tool Access
+
+```python
+# Only grant necessary tools
+options = ClaudeAgentOptions(
+    allowed_tools=["Read", "Grep"],  # Read-only access
+)
+```
+
+### 3. Set Working Directory
+
+```python
+options = ClaudeAgentOptions(
+    cwd="/path/to/project"  # Constrain file operations
+)
+```
+
+### 4. Use Custom Tool Filtering
+
+```python
+def filter_tools(tool_name: str) -> bool:
+    dangerous = ["Bash", "Write"]
+    return tool_name not in dangerous
+
+options = ClaudeAgentOptions(can_use_tool=filter_tools)
+```
+
+### 5. Handle Streaming Properly
+
+```python
+async for message in query(prompt="Task"):
+    if isinstance(message, AssistantMessage):
+        for block in message.content:
+            if isinstance(block, TextBlock):
+                # Stream output as it arrives
+                print(block.text, end="", flush=True)
+```
+
+---
+
+## Complete Examples
+
+See the [examples/](./examples/) directory for:
+- `quick_start.py` - Basic usage
+- `streaming_mode.py` - Streaming responses
+- `mcp_calculator.py` - Custom MCP tools
+- `multi_agent.py` - Multi-agent coordination
+- `quick_start.ts` - TypeScript basics
+
+---
+
+## Resources
+
+### Official Documentation
+- [SDK Overview](https://docs.claude.com/en/api/agent-sdk/overview)
+- [Python SDK Reference](https://docs.anthropic.com/en/docs/claude-code/sdk/sdk-python)
+- [TypeScript SDK Reference](https://docs.anthropic.com/en/docs/claude-code/sdk/sdk-typescript)
+
+### GitHub Repositories
+- [Python SDK](https://github.com/anthropics/claude-agent-sdk-python)
+- [TypeScript SDK](https://github.com/anthropics/claude-agent-sdk-typescript)
+
+### Claude Code Documentation
+- [Settings Reference](https://docs.anthropic.com/en/docs/claude-code/settings)
+- [Hooks Guide](https://docs.anthropic.com/en/docs/claude-code/hooks)
+- [Plugins Guide](https://docs.anthropic.com/en/docs/claude-code/plugins)

--- a/registry/skills/claude-agent-sdk/examples/custom_tools.py
+++ b/registry/skills/claude-agent-sdk/examples/custom_tools.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+Claude Agent SDK - Custom Tools Example
+
+This example demonstrates creating custom tools using in-process MCP servers.
+"""
+
+import anyio
+import json
+from datetime import datetime
+from claude_agent_sdk import (
+    query,
+    ClaudeAgentOptions,
+    tool,
+    create_sdk_mcp_server,
+    AssistantMessage,
+    TextBlock,
+    ToolUseBlock,
+    ResultMessage,
+)
+
+
+# Define custom tools using the @tool decorator
+@tool(
+    name="get_current_time",
+    description="Get the current date and time",
+    input_schema={}
+)
+async def get_current_time(args):
+    """Return the current time."""
+    now = datetime.now()
+    return {
+        "content": [{
+            "type": "text",
+            "text": now.strftime("%Y-%m-%d %H:%M:%S")
+        }]
+    }
+
+
+@tool(
+    name="calculate",
+    description="Perform a mathematical calculation",
+    input_schema={
+        "expression": {
+            "type": "string",
+            "description": "Mathematical expression to evaluate (e.g., '2 + 2')"
+        }
+    }
+)
+async def calculate(args):
+    """Safely evaluate a mathematical expression."""
+    expression = args.get("expression", "")
+
+    # Safe evaluation - only allow numbers and basic operators
+    allowed_chars = set("0123456789+-*/.() ")
+    if not all(c in allowed_chars for c in expression):
+        return {
+            "content": [{
+                "type": "text",
+                "text": "Error: Expression contains invalid characters"
+            }]
+        }
+
+    try:
+        result = eval(expression)  # Safe due to character filtering
+        return {
+            "content": [{
+                "type": "text",
+                "text": f"{expression} = {result}"
+            }]
+        }
+    except Exception as e:
+        return {
+            "content": [{
+                "type": "text",
+                "text": f"Error: {str(e)}"
+            }]
+        }
+
+
+@tool(
+    name="save_note",
+    description="Save a note to the notes database",
+    input_schema={
+        "title": {
+            "type": "string",
+            "description": "Title of the note"
+        },
+        "content": {
+            "type": "string",
+            "description": "Content of the note"
+        }
+    }
+)
+async def save_note(args):
+    """Save a note to a JSON file."""
+    title = args.get("title", "Untitled")
+    content = args.get("content", "")
+
+    note = {
+        "title": title,
+        "content": content,
+        "created_at": datetime.now().isoformat()
+    }
+
+    # In a real app, you'd save to a database
+    print(f"[Saving note: {title}]")
+
+    return {
+        "content": [{
+            "type": "text",
+            "text": f"Note '{title}' saved successfully"
+        }]
+    }
+
+
+@tool(
+    name="get_weather",
+    description="Get weather information for a location",
+    input_schema={
+        "location": {
+            "type": "string",
+            "description": "City name or location"
+        }
+    }
+)
+async def get_weather(args):
+    """Mock weather service - replace with real API call."""
+    location = args.get("location", "Unknown")
+
+    # Mock data - in production, call a real weather API
+    weather_data = {
+        "location": location,
+        "temperature": "72°F",
+        "condition": "Sunny",
+        "humidity": "45%"
+    }
+
+    return {
+        "content": [{
+            "type": "text",
+            "text": json.dumps(weather_data, indent=2)
+        }]
+    }
+
+
+async def main():
+    """Run custom tools example."""
+    print("=== Custom Tools Example ===\n")
+
+    # Create an in-process MCP server with our custom tools
+    custom_server = create_sdk_mcp_server(
+        name="my-tools",
+        version="1.0.0",
+        tools=[get_current_time, calculate, save_note, get_weather]
+    )
+
+    # Configure options with our custom tools
+    options = ClaudeAgentOptions(
+        system_prompt="""You are a helpful assistant with access to custom tools.
+Available tools:
+- get_current_time: Get the current date and time
+- calculate: Perform mathematical calculations
+- save_note: Save notes to the database
+- get_weather: Get weather for a location
+
+Use these tools to help the user.""",
+        mcp_servers=[custom_server],
+        allowed_tools=[
+            "mcp__my-tools__get_current_time",
+            "mcp__my-tools__calculate",
+            "mcp__my-tools__save_note",
+            "mcp__my-tools__get_weather",
+        ],
+        permission_mode="acceptEdits"
+    )
+
+    # Test the custom tools
+    prompts = [
+        "What time is it right now?",
+        "Calculate 15 * 7 + 23",
+        "Save a note titled 'Meeting' with content 'Team sync at 3pm'",
+        "What's the weather in San Francisco?",
+    ]
+
+    for prompt in prompts:
+        print(f"User: {prompt}\n")
+
+        async for message in query(prompt=prompt, options=options):
+            if isinstance(message, AssistantMessage):
+                for block in message.content:
+                    if isinstance(block, TextBlock):
+                        print(f"Assistant: {block.text}")
+                    elif isinstance(block, ToolUseBlock):
+                        print(f"[Tool: {block.name}]")
+            elif isinstance(message, ResultMessage):
+                print()
+                break
+
+        print("-" * 40 + "\n")
+
+
+if __name__ == "__main__":
+    anyio.run(main)

--- a/registry/skills/claude-agent-sdk/examples/custom_tools.ts
+++ b/registry/skills/claude-agent-sdk/examples/custom_tools.ts
@@ -1,0 +1,188 @@
+/**
+ * Claude Agent SDK - Custom Tools Example (TypeScript)
+ *
+ * This example demonstrates creating custom tools using in-process MCP servers.
+ */
+
+import {
+  query,
+  createSdkMcpServer,
+  tool,
+  type ClaudeAgentOptions,
+  type ToolDefinition,
+} from "@anthropic-ai/claude-agent-sdk";
+
+// Define custom tools
+
+const getCurrentTime = tool({
+  name: "get_current_time",
+  description: "Get the current date and time",
+  inputSchema: {
+    type: "object",
+    properties: {},
+    required: [],
+  },
+  execute: async () => {
+    const now = new Date();
+    return now.toISOString();
+  },
+});
+
+const calculate = tool({
+  name: "calculate",
+  description: "Perform a mathematical calculation",
+  inputSchema: {
+    type: "object",
+    properties: {
+      expression: {
+        type: "string",
+        description: "Mathematical expression to evaluate (e.g., '2 + 2')",
+      },
+    },
+    required: ["expression"],
+  },
+  execute: async (input: { expression: string }) => {
+    const { expression } = input;
+
+    // Safe evaluation - only allow numbers and basic operators
+    const allowedChars = new Set("0123456789+-*/.() ".split(""));
+    const isValid = [...expression].every((c) => allowedChars.has(c));
+
+    if (!isValid) {
+      return "Error: Expression contains invalid characters";
+    }
+
+    try {
+      // Use Function constructor for safer eval
+      const result = new Function(`return ${expression}`)();
+      return `${expression} = ${result}`;
+    } catch (error) {
+      return `Error: ${error instanceof Error ? error.message : "Unknown error"}`;
+    }
+  },
+});
+
+const saveNote = tool({
+  name: "save_note",
+  description: "Save a note to the notes database",
+  inputSchema: {
+    type: "object",
+    properties: {
+      title: {
+        type: "string",
+        description: "Title of the note",
+      },
+      content: {
+        type: "string",
+        description: "Content of the note",
+      },
+    },
+    required: ["title", "content"],
+  },
+  execute: async (input: { title: string; content: string }) => {
+    const { title, content } = input;
+
+    const note = {
+      title,
+      content,
+      createdAt: new Date().toISOString(),
+    };
+
+    // In a real app, you'd save to a database
+    console.log(`[Saving note: ${title}]`);
+
+    return `Note '${title}' saved successfully`;
+  },
+});
+
+const getWeather = tool({
+  name: "get_weather",
+  description: "Get weather information for a location",
+  inputSchema: {
+    type: "object",
+    properties: {
+      location: {
+        type: "string",
+        description: "City name or location",
+      },
+    },
+    required: ["location"],
+  },
+  execute: async (input: { location: string }) => {
+    const { location } = input;
+
+    // Mock data - in production, call a real weather API
+    const weatherData = {
+      location,
+      temperature: "72°F",
+      condition: "Sunny",
+      humidity: "45%",
+    };
+
+    return JSON.stringify(weatherData, null, 2);
+  },
+});
+
+async function main(): Promise<void> {
+  console.log("=== Custom Tools Example (TypeScript) ===\n");
+
+  // Create an in-process MCP server with our custom tools
+  const customServer = createSdkMcpServer({
+    name: "my-tools",
+    version: "1.0.0",
+    tools: [getCurrentTime, calculate, saveNote, getWeather],
+  });
+
+  // Configure options with our custom tools
+  const options: ClaudeAgentOptions = {
+    systemPrompt: `You are a helpful assistant with access to custom tools.
+Available tools:
+- get_current_time: Get the current date and time
+- calculate: Perform mathematical calculations
+- save_note: Save notes to the database
+- get_weather: Get weather for a location
+
+Use these tools to help the user.`,
+    mcpServers: [customServer],
+    allowedTools: [
+      "mcp__my-tools__get_current_time",
+      "mcp__my-tools__calculate",
+      "mcp__my-tools__save_note",
+      "mcp__my-tools__get_weather",
+    ],
+    permissionMode: "acceptEdits",
+  };
+
+  // Test the custom tools
+  const prompts = [
+    "What time is it right now?",
+    "Calculate 15 * 7 + 23",
+    "Save a note titled 'Meeting' with content 'Team sync at 3pm'",
+    "What's the weather in San Francisco?",
+  ];
+
+  for (const prompt of prompts) {
+    console.log(`User: ${prompt}\n`);
+
+    const stream = query({ prompt, options });
+
+    for await (const message of stream) {
+      if (message.type === "assistant") {
+        for (const block of message.message.content) {
+          if (block.type === "text") {
+            console.log(`Assistant: ${block.text}`);
+          } else if (block.type === "tool_use") {
+            console.log(`[Tool: ${block.name}]`);
+          }
+        }
+      } else if (message.type === "result") {
+        console.log();
+        break;
+      }
+    }
+
+    console.log("-".repeat(40) + "\n");
+  }
+}
+
+main().catch(console.error);

--- a/registry/skills/claude-agent-sdk/examples/hooks.py
+++ b/registry/skills/claude-agent-sdk/examples/hooks.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""
+Claude Agent SDK - Hooks Example
+
+This example demonstrates using hooks with Claude Code SDK.
+Based on official Anthropic SDK examples from:
+https://github.com/anthropics/claude-agent-sdk-python/blob/main/examples/hooks.py
+
+Hooks are Python functions that the Claude Code application invokes at
+specific points of the Claude agent loop. They enable deterministic
+processing and automated feedback.
+"""
+
+import asyncio
+import logging
+from typing import Any
+
+from claude_agent_sdk import (
+    ClaudeAgentOptions,
+    ClaudeSDKClient,
+    AssistantMessage,
+    ResultMessage,
+    TextBlock,
+)
+from claude_agent_sdk.types import (
+    HookContext,
+    HookInput,
+    HookJSONOutput,
+    HookMatcher,
+    Message,
+)
+
+# Set up logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def display_message(msg: Message) -> None:
+    """Standardized message display function."""
+    if isinstance(msg, AssistantMessage):
+        for block in msg.content:
+            if isinstance(block, TextBlock):
+                print(f"Claude: {block.text}")
+    elif isinstance(msg, ResultMessage):
+        print("Result ended")
+
+
+# ============================================================================
+# Hook Callback Functions
+# ============================================================================
+
+async def check_bash_command(
+    input_data: HookInput,
+    tool_use_id: str | None,
+    context: HookContext
+) -> HookJSONOutput:
+    """
+    PreToolUse hook that blocks certain bash commands.
+
+    This hook examines bash commands before execution and can deny
+    commands that match blocked patterns.
+    """
+    tool_name = input_data["tool_name"]
+    tool_input = input_data["tool_input"]
+
+    if tool_name != "Bash":
+        return {}
+
+    command = tool_input.get("command", "")
+    block_patterns = ["rm -rf", "sudo", "curl | bash"]
+
+    for pattern in block_patterns:
+        if pattern in command:
+            logger.warning(f"Blocked command: {command}")
+            return {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": f"Command contains blocked pattern: {pattern}",
+                }
+            }
+
+    return {}
+
+
+async def add_custom_instructions(
+    input_data: HookInput,
+    tool_use_id: str | None,
+    context: HookContext
+) -> HookJSONOutput:
+    """
+    UserPromptSubmit hook that adds custom context.
+
+    This hook runs when the user submits a prompt and can inject
+    additional context into the conversation.
+    """
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": "Remember: Always explain your reasoning step by step.",
+        }
+    }
+
+
+async def review_tool_output(
+    input_data: HookInput,
+    tool_use_id: str | None,
+    context: HookContext
+) -> HookJSONOutput:
+    """
+    PostToolUse hook that reviews tool output.
+
+    This hook runs after a tool completes and can provide
+    additional context or warnings based on the output.
+    """
+    tool_response = input_data.get("tool_response", "")
+
+    if "error" in str(tool_response).lower():
+        return {
+            "systemMessage": "⚠️ The command produced an error",
+            "reason": "Tool execution failed",
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "additionalContext": "Consider trying a different approach.",
+            }
+        }
+
+    return {}
+
+
+async def strict_approval_hook(
+    input_data: HookInput,
+    tool_use_id: str | None,
+    context: HookContext
+) -> HookJSONOutput:
+    """
+    PreToolUse hook demonstrating permissionDecision control.
+
+    This hook explicitly allows or denies tool execution based
+    on security policies.
+    """
+    tool_name = input_data.get("tool_name")
+    tool_input = input_data.get("tool_input", {})
+
+    # Block Write operations to specific files
+    if tool_name == "Write":
+        file_path = tool_input.get("file_path", "")
+        if "important" in file_path.lower() or ".env" in file_path:
+            logger.warning(f"Blocked Write to: {file_path}")
+            return {
+                "reason": "Security policy blocks writes to sensitive files",
+                "systemMessage": "🚫 Write operation blocked by security policy",
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": "Security policy blocks writes to sensitive files",
+                },
+            }
+
+    # Allow everything else
+    return {
+        "reason": "Tool use approved",
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "permissionDecisionReason": "Tool passed security checks",
+        },
+    }
+
+
+# ============================================================================
+# Examples
+# ============================================================================
+
+async def example_pretooluse() -> None:
+    """Demonstrate PreToolUse hook that blocks dangerous commands."""
+    print("=== PreToolUse Example ===")
+    print("This example shows how PreToolUse can block dangerous bash commands.\n")
+
+    options = ClaudeAgentOptions(
+        allowed_tools=["Bash"],
+        hooks={
+            "PreToolUse": [
+                HookMatcher(matcher="Bash", hooks=[check_bash_command]),
+            ],
+        }
+    )
+
+    async with ClaudeSDKClient(options=options) as client:
+        # Test 1: Dangerous command (will be blocked)
+        print("Test 1: Trying 'rm -rf /' (should be blocked)...")
+        await client.query("Run: echo test && rm -rf /")
+
+        async for msg in client.receive_response():
+            display_message(msg)
+
+        print("\n" + "=" * 50 + "\n")
+
+        # Test 2: Safe command (should work)
+        print("Test 2: Trying 'echo hello' (should work)...")
+        await client.query("Run: echo 'Hello from hooks!'")
+
+        async for msg in client.receive_response():
+            display_message(msg)
+
+
+async def example_userpromptsubmit() -> None:
+    """Demonstrate UserPromptSubmit hook that adds context."""
+    print("\n=== UserPromptSubmit Example ===")
+    print("This example shows how to inject context via UserPromptSubmit.\n")
+
+    options = ClaudeAgentOptions(
+        hooks={
+            "UserPromptSubmit": [
+                HookMatcher(matcher=None, hooks=[add_custom_instructions]),
+            ],
+        }
+    )
+
+    async with ClaudeSDKClient(options=options) as client:
+        await client.query("What is 2 + 2?")
+
+        async for msg in client.receive_response():
+            display_message(msg)
+
+
+async def example_posttooluse() -> None:
+    """Demonstrate PostToolUse hook that reviews output."""
+    print("\n=== PostToolUse Example ===")
+    print("This example shows how PostToolUse can review tool output.\n")
+
+    options = ClaudeAgentOptions(
+        allowed_tools=["Bash"],
+        hooks={
+            "PostToolUse": [
+                HookMatcher(matcher="Bash", hooks=[review_tool_output]),
+            ],
+        }
+    )
+
+    async with ClaudeSDKClient(options=options) as client:
+        print("Running a command that will produce an error...")
+        await client.query("Run: ls /nonexistent_directory_12345")
+
+        async for msg in client.receive_response():
+            display_message(msg)
+
+
+async def main():
+    """Run all hook examples."""
+    print("=" * 60)
+    print("Claude Agent SDK - Hooks Examples")
+    print("=" * 60)
+
+    await example_pretooluse()
+    await example_userpromptsubmit()
+    await example_posttooluse()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/registry/skills/claude-agent-sdk/examples/multi_turn.py
+++ b/registry/skills/claude-agent-sdk/examples/multi_turn.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+Claude Agent SDK - Multi-Turn Conversation Example
+
+This example demonstrates stateful conversations using ClaudeSDKClient.
+"""
+
+import anyio
+from claude_agent_sdk import (
+    ClaudeSDKClient,
+    ClaudeAgentOptions,
+    AssistantMessage,
+    TextBlock,
+    ResultMessage,
+)
+
+
+async def multi_turn_conversation():
+    """Demonstrate multi-turn conversation with context preservation."""
+    print("=== Multi-Turn Conversation ===\n")
+
+    options = ClaudeAgentOptions(
+        system_prompt="You are a helpful coding tutor. Remember what we discuss.",
+        allowed_tools=["Read", "Write"],
+        permission_mode="acceptEdits",
+    )
+
+    async with ClaudeSDKClient(options=options) as client:
+        # First turn
+        print("User: Explain what a Python decorator is.\n")
+        await client.query("Explain what a Python decorator is.")
+
+        async for message in client.receive_messages():
+            if isinstance(message, AssistantMessage):
+                for block in message.content:
+                    if isinstance(block, TextBlock):
+                        print(f"Assistant: {block.text}\n")
+            elif isinstance(message, ResultMessage):
+                break
+
+        # Second turn - Claude remembers context
+        print("User: Now show me an example of one.\n")
+        await client.query("Now show me an example of one.")
+
+        async for message in client.receive_messages():
+            if isinstance(message, AssistantMessage):
+                for block in message.content:
+                    if isinstance(block, TextBlock):
+                        print(f"Assistant: {block.text}\n")
+            elif isinstance(message, ResultMessage):
+                break
+
+        # Third turn - building on previous context
+        print("User: Can you create a timing decorator and save it to timing.py?\n")
+        await client.query("Can you create a timing decorator and save it to timing.py?")
+
+        async for message in client.receive_messages():
+            if isinstance(message, AssistantMessage):
+                for block in message.content:
+                    if isinstance(block, TextBlock):
+                        print(f"Assistant: {block.text}\n")
+            elif isinstance(message, ResultMessage):
+                break
+
+
+async def session_management():
+    """Demonstrate session persistence and forking."""
+    print("\n=== Session Management ===\n")
+
+    options = ClaudeAgentOptions(
+        system_prompt="You are a project planner."
+    )
+
+    session_id = None
+
+    # First session - establish context
+    async with ClaudeSDKClient(options=options) as client:
+        await client.query("Let's plan a web application. It should have user auth and a dashboard.")
+
+        async for message in client.receive_messages():
+            if hasattr(message, 'session_id'):
+                session_id = message.session_id
+            if isinstance(message, AssistantMessage):
+                for block in message.content:
+                    if isinstance(block, TextBlock):
+                        print(f"Planning: {block.text[:200]}...\n")
+            elif isinstance(message, ResultMessage):
+                break
+
+    if session_id:
+        print(f"Session ID: {session_id}\n")
+
+        # Resume session later
+        async with ClaudeSDKClient(options=options) as client:
+            await client.query(
+                "What were the main features we discussed?",
+                resume_session=session_id
+            )
+
+            async for message in client.receive_messages():
+                if isinstance(message, AssistantMessage):
+                    for block in message.content:
+                        if isinstance(block, TextBlock):
+                            print(f"Resumed: {block.text[:200]}...\n")
+                elif isinstance(message, ResultMessage):
+                    break
+
+
+async def main():
+    await multi_turn_conversation()
+    await session_management()
+
+
+if __name__ == "__main__":
+    anyio.run(main)

--- a/registry/skills/claude-agent-sdk/examples/quick_start.py
+++ b/registry/skills/claude-agent-sdk/examples/quick_start.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+Claude Agent SDK - Quick Start Example
+
+This example demonstrates basic usage of the Claude Agent SDK in Python.
+"""
+
+import anyio
+from claude_agent_sdk import (
+    query,
+    ClaudeAgentOptions,
+    AssistantMessage,
+    TextBlock,
+    ToolUseBlock,
+    ResultMessage,
+)
+
+
+async def simple_query():
+    """Basic query without options."""
+    print("=== Simple Query ===\n")
+
+    async for message in query(prompt="What is 2 + 2?"):
+        if isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, TextBlock):
+                    print(block.text)
+        elif isinstance(message, ResultMessage):
+            print(f"\n[Completed: {message.subtype}]")
+
+
+async def query_with_options():
+    """Query with custom options."""
+    print("\n=== Query with Options ===\n")
+
+    options = ClaudeAgentOptions(
+        system_prompt="You are a helpful Python expert. Be concise.",
+        max_turns=3,
+    )
+
+    async for message in query(
+        prompt="Write a function to calculate factorial",
+        options=options
+    ):
+        if isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, TextBlock):
+                    print(block.text)
+
+
+async def query_with_tools():
+    """Query with tool access enabled."""
+    print("\n=== Query with Tools ===\n")
+
+    options = ClaudeAgentOptions(
+        system_prompt="You are a file system assistant.",
+        allowed_tools=["Read", "Glob", "Grep"],
+        permission_mode="acceptEdits",
+        cwd=".",  # Current directory
+    )
+
+    async for message in query(
+        prompt="List all Python files in the current directory",
+        options=options
+    ):
+        if isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, TextBlock):
+                    print(block.text)
+                elif isinstance(block, ToolUseBlock):
+                    print(f"[Using tool: {block.name}]")
+
+
+async def streaming_output():
+    """Stream output as it arrives."""
+    print("\n=== Streaming Output ===\n")
+
+    options = ClaudeAgentOptions(
+        system_prompt="You are a storyteller. Write short stories."
+    )
+
+    async for message in query(
+        prompt="Write a very short story about a robot (2-3 sentences)",
+        options=options
+    ):
+        if isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, TextBlock):
+                    # Print without newline for streaming effect
+                    print(block.text, end="", flush=True)
+
+    print()  # Final newline
+
+
+async def main():
+    """Run all examples."""
+    await simple_query()
+    await query_with_options()
+    await query_with_tools()
+    await streaming_output()
+
+
+if __name__ == "__main__":
+    anyio.run(main)

--- a/registry/skills/claude-agent-sdk/examples/quick_start.ts
+++ b/registry/skills/claude-agent-sdk/examples/quick_start.ts
@@ -1,0 +1,136 @@
+/**
+ * Claude Agent SDK - Quick Start Example (TypeScript)
+ *
+ * This example demonstrates basic usage of the Claude Agent SDK in TypeScript.
+ */
+
+import {
+  query,
+  type ClaudeAgentOptions,
+  type Message,
+} from "@anthropic-ai/claude-agent-sdk";
+
+/**
+ * Basic query without options.
+ */
+async function simpleQuery(): Promise<void> {
+  console.log("=== Simple Query ===\n");
+
+  const stream = query({ prompt: "What is 2 + 2?" });
+
+  for await (const message of stream) {
+    if (message.type === "assistant") {
+      for (const block of message.message.content) {
+        if (block.type === "text") {
+          console.log(block.text);
+        }
+      }
+    } else if (message.type === "result") {
+      console.log(`\n[Completed: ${message.subtype}]`);
+    }
+  }
+}
+
+/**
+ * Query with custom options.
+ */
+async function queryWithOptions(): Promise<void> {
+  console.log("\n=== Query with Options ===\n");
+
+  const options: ClaudeAgentOptions = {
+    systemPrompt: "You are a helpful TypeScript expert. Be concise.",
+    maxTurns: 3,
+  };
+
+  const stream = query({
+    prompt: "Write a function to calculate factorial",
+    options,
+  });
+
+  for await (const message of stream) {
+    if (message.type === "assistant") {
+      for (const block of message.message.content) {
+        if (block.type === "text") {
+          console.log(block.text);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Query with tool access enabled.
+ */
+async function queryWithTools(): Promise<void> {
+  console.log("\n=== Query with Tools ===\n");
+
+  const options: ClaudeAgentOptions = {
+    systemPrompt: "You are a file system assistant.",
+    allowedTools: ["Read", "Glob", "Grep"],
+    permissionMode: "acceptEdits",
+    cwd: ".", // Current directory
+  };
+
+  const stream = query({
+    prompt: "List all TypeScript files in the current directory",
+    options,
+  });
+
+  for await (const message of stream) {
+    if (message.type === "assistant") {
+      for (const block of message.message.content) {
+        if (block.type === "text") {
+          console.log(block.text);
+        } else if (block.type === "tool_use") {
+          console.log(`[Using tool: ${block.name}]`);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Stream output as it arrives.
+ */
+async function streamingOutput(): Promise<void> {
+  console.log("\n=== Streaming Output ===\n");
+
+  const options: ClaudeAgentOptions = {
+    systemPrompt: "You are a storyteller. Write short stories.",
+  };
+
+  const stream = query({
+    prompt: "Write a very short story about a robot (2-3 sentences)",
+    options,
+  });
+
+  for await (const message of stream) {
+    if (message.type === "assistant") {
+      for (const block of message.message.content) {
+        if (block.type === "text") {
+          // Write without newline for streaming effect
+          process.stdout.write(block.text);
+        }
+      }
+    }
+  }
+
+  console.log(); // Final newline
+}
+
+/**
+ * Run all examples.
+ */
+async function main(): Promise<void> {
+  try {
+    await simpleQuery();
+    await queryWithOptions();
+    await queryWithTools();
+    await streamingOutput();
+  } catch (error) {
+    console.error("Error:", error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/registry/skills/claude-agent-sdk/resources/feature-parity.md
+++ b/registry/skills/claude-agent-sdk/resources/feature-parity.md
@@ -1,0 +1,334 @@
+# Claude Code vs Claude Agent SDK: Feature Parity Guide
+
+This document provides a comprehensive comparison between Claude Code (the CLI/web interface) and the Claude Agent SDK (programmatic API).
+
+## Feature Comparison Matrix
+
+### Core Capabilities
+
+| Feature | Claude Code CLI | Claude Agent SDK | Notes |
+|---------|----------------|------------------|-------|
+| Text conversations | Yes | Yes | Identical capability |
+| File reading | Yes | Yes | Via `Read` tool |
+| File writing | Yes | Yes | Via `Write` tool |
+| File editing | Yes | Yes | Via `Edit` tool |
+| Shell execution | Yes | Yes | Via `Bash` tool |
+| Web search | Yes | Yes | Via `WebSearch` tool |
+| Web fetch | Yes | Yes | Via `WebFetch` tool |
+| Pattern search (grep) | Yes | Yes | Via `Grep` tool |
+| File globbing | Yes | Yes | Via `Glob` tool |
+| Jupyter notebooks | Yes | Yes | Via `NotebookEdit` tool |
+| Subagent spawning | Yes | Yes | Via `Task` tool |
+
+### User Interface
+
+| Feature | Claude Code CLI | Claude Agent SDK | Notes |
+|---------|----------------|------------------|-------|
+| Interactive REPL | Yes | No | SDK is programmatic only |
+| Terminal UI | Yes | No | SDK runs headless |
+| VS Code extension | Yes | No | IDE integration is CLI only |
+| JetBrains plugin | Yes | No | IDE integration is CLI only |
+| Web interface | Yes | No | Available via claude.ai |
+| Streaming output | Yes | Yes | Both support streaming |
+
+### Configuration & Customization
+
+| Feature | Claude Code CLI | Claude Agent SDK | SDK Equivalent |
+|---------|----------------|------------------|----------------|
+| System prompt | CLAUDE.md | `system_prompt` option | Direct parameter |
+| Settings files | settings.json | `setting_sources` option | Load via option |
+| Slash commands | `/command` syntax | Load via `setting_sources` | Auto-loaded from project |
+| Custom skills | .claude/skills/ | Load via `setting_sources` | Auto-loaded from project |
+| Custom agents | .claude/agents/ | Load via `setting_sources` | Auto-loaded from project |
+| Plugins | `/plugin` command | Not directly supported | Manual asset loading |
+| Permission rules | settings.json | `allowed_tools`, `can_use_tool` | Programmatic control |
+| Model selection | `/model` command | Environment variables | `ANTHROPIC_MODEL` |
+
+### Hooks & Automation
+
+| Feature | Claude Code CLI | Claude Agent SDK | SDK Equivalent |
+|---------|----------------|------------------|----------------|
+| SessionStart hook | settings.json | Not needed | Pre-execution code |
+| SessionEnd hook | settings.json | Not needed | Post-execution code |
+| PreToolUse hook | settings.json | `hooks` option | Programmatic hooks |
+| PostToolUse hook | settings.json | `hooks` option | Programmatic hooks |
+| UserPromptSubmit hook | settings.json | Not needed | Pre-query logic |
+| Stop hook | settings.json | Not needed | Post-query logic |
+| Custom scripts | Shell scripts | Python/TS functions | Native code |
+
+### MCP (Model Context Protocol)
+
+| Feature | Claude Code CLI | Claude Agent SDK | Notes |
+|---------|----------------|------------------|-------|
+| External MCP servers | .mcp.json | `mcp_servers` option | Both supported |
+| In-process MCP | No | Yes | SDK advantage |
+| Custom tools | Via MCP servers | `@tool` decorator | SDK has native support |
+| Tool namespacing | `mcp__server__tool` | `mcp__server__tool` | Same convention |
+| Server auto-discovery | Yes | Via `setting_sources` | Load from .mcp.json |
+
+### Session Management
+
+| Feature | Claude Code CLI | Claude Agent SDK | Notes |
+|---------|----------------|------------------|-------|
+| Session persistence | Automatic | Manual | `resume_session` option |
+| Session forking | Not exposed | Yes | `fork_session` option |
+| Multi-turn conversations | Yes | Yes (ClaudeSDKClient) | Stateful client required |
+| Context compaction | Automatic | Automatic | Same behavior |
+| Session cleanup | Automatic | Manual | Handle in application |
+
+### Security & Permissions
+
+| Feature | Claude Code CLI | Claude Agent SDK | Notes |
+|---------|----------------|------------------|-------|
+| Permission modes | 4 modes | 2 modes | acceptEdits, manual |
+| Tool allowlisting | settings.json | `allowed_tools` | Array of tool names |
+| Tool denylisting | settings.json | `disallowed_tools` | Array of tool names |
+| Runtime filtering | No | Yes | `can_use_tool` callback |
+| Sandbox mode | Yes | No | CLI-only feature |
+| Enterprise policies | managed-settings.json | No | Enterprise CLI feature |
+
+### Authentication
+
+| Feature | Claude Code CLI | Claude Agent SDK | Notes |
+|---------|----------------|------------------|-------|
+| Claude.ai login | `/login` | No | CLI interactive login |
+| API key auth | Environment var | Environment var | `ANTHROPIC_API_KEY` |
+| Bedrock auth | Environment var | Environment var | `CLAUDE_CODE_USE_BEDROCK` |
+| Vertex AI auth | Environment var | Environment var | `CLAUDE_CODE_USE_VERTEX` |
+| Foundry auth | Environment var | Environment var | `CLAUDE_CODE_USE_FOUNDRY` |
+| Custom auth | apiKeyHelper | apiKeyHelper | Same mechanism |
+
+---
+
+## Migration Guide: CLI to SDK
+
+### 1. System Prompts
+
+**CLI (CLAUDE.md):**
+```markdown
+# Project Guidelines
+You are a Python expert...
+```
+
+**SDK:**
+```python
+options = ClaudeAgentOptions(
+    system_prompt="You are a Python expert..."
+)
+```
+
+### 2. Slash Commands
+
+**CLI:**
+```bash
+/review  # Invokes .claude/commands/review.md
+```
+
+**SDK:**
+```python
+# Load project commands automatically
+options = ClaudeAgentOptions(setting_sources=["project"])
+
+# Or read command file directly
+with open(".claude/commands/review.md") as f:
+    command_prompt = f.read()
+await client.query(command_prompt)
+```
+
+### 3. Skills
+
+**CLI:** Auto-loaded from `.claude/skills/`
+
+**SDK:**
+```python
+# Auto-load project skills
+options = ClaudeAgentOptions(setting_sources=["project"])
+```
+
+### 4. Hooks
+
+**CLI (settings.json):**
+```json
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Bash",
+      "hooks": [{"type": "command", "command": "./validate.sh"}]
+    }]
+  }
+}
+```
+
+**SDK:**
+```python
+# Implement as Python logic
+async def pre_tool_hook(tool_name: str, args: dict) -> bool:
+    if tool_name == "Bash":
+        return validate_command(args["command"])
+    return True
+
+# Or use hooks option
+options = ClaudeAgentOptions(
+    hooks={
+        "PreToolUse": [{
+            "matcher": "Bash",
+            "hooks": [{"type": "command", "command": "./validate.sh"}]
+        }]
+    }
+)
+```
+
+### 5. Permissions
+
+**CLI (settings.json):**
+```json
+{
+  "permissions": {
+    "allow": ["Bash(npm run:*)"],
+    "deny": ["Read(.env)"]
+  }
+}
+```
+
+**SDK:**
+```python
+options = ClaudeAgentOptions(
+    allowed_tools=["Read", "Write", "Bash"],
+    can_use_tool=lambda name: name not in ["WebFetch"]
+)
+```
+
+### 6. MCP Servers
+
+**CLI (.mcp.json):**
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"]
+    }
+  }
+}
+```
+
+**SDK:**
+```python
+# Load from project
+options = ClaudeAgentOptions(setting_sources=["project"])
+
+# Or create in-process
+@tool("my_tool", "Description", {"arg": str})
+async def my_tool(args):
+    return {"content": [{"type": "text", "text": "Result"}]}
+
+server = create_sdk_mcp_server(name="custom", tools=[my_tool])
+options = ClaudeAgentOptions(mcp_servers=[server])
+```
+
+---
+
+## SDK-Only Features
+
+Features available in the SDK but not the CLI:
+
+### 1. In-Process MCP Servers
+
+```python
+@tool("calculate", "Perform calculation", {"expression": str})
+async def calculate(args):
+    result = eval(args["expression"])  # Use safe eval in production
+    return {"content": [{"type": "text", "text": str(result)}]}
+
+server = create_sdk_mcp_server(name="math", tools=[calculate])
+```
+
+### 2. Runtime Tool Filtering
+
+```python
+def dynamic_filter(tool_name: str) -> bool:
+    # Complex runtime logic
+    if is_production():
+        return tool_name in SAFE_TOOLS
+    return True
+
+options = ClaudeAgentOptions(can_use_tool=dynamic_filter)
+```
+
+### 3. Session Forking
+
+```python
+# Create alternative branches from a conversation point
+await client.query(
+    "Try approach B instead",
+    resume_session=session_id,
+    fork_session=True
+)
+```
+
+### 4. Programmatic Multi-Agent Orchestration
+
+```python
+async def orchestrate():
+    # Run specialized agents in sequence or parallel
+    architect = ClaudeSDKClient(ClaudeAgentOptions(
+        system_prompt="You are a software architect"
+    ))
+
+    implementer = ClaudeSDKClient(ClaudeAgentOptions(
+        system_prompt="You are an implementation expert"
+    ))
+
+    # Coordinate results between agents
+    design = await run_agent(architect, "Design the system")
+    code = await run_agent(implementer, f"Implement: {design}")
+```
+
+---
+
+## CLI-Only Features
+
+Features available in CLI but not the SDK:
+
+1. **Interactive REPL** - Real-time conversation interface
+2. **IDE Integration** - VS Code and JetBrains plugins
+3. **Plugin System** - `/plugin` command for marketplace
+4. **Sandbox Mode** - Isolated execution environment
+5. **Enterprise Policies** - managed-settings.json
+6. **Interactive Login** - `/login` OAuth flow
+7. **Visual Diff Review** - Interactive edit approval
+8. **Auto-updater** - Automatic version updates
+
+---
+
+## Choosing Between CLI and SDK
+
+### Use Claude Code CLI when:
+- Working interactively on development tasks
+- Need IDE integration (VS Code, JetBrains)
+- Using plugins from the marketplace
+- Require sandbox isolation
+- Enterprise policy management needed
+
+### Use Claude Agent SDK when:
+- Building automated pipelines
+- Creating custom AI-powered applications
+- Need programmatic control over agent behavior
+- Implementing custom tools with `@tool` decorator
+- Orchestrating multi-agent systems
+- Embedding Claude capabilities in services
+
+---
+
+## Environment Variables Reference
+
+| Variable | CLI | SDK | Description |
+|----------|-----|-----|-------------|
+| `ANTHROPIC_API_KEY` | Yes | Yes | API authentication |
+| `ANTHROPIC_MODEL` | Yes | Yes | Model selection |
+| `CLAUDE_CODE_USE_BEDROCK` | Yes | Yes | Enable Bedrock |
+| `CLAUDE_CODE_USE_VERTEX` | Yes | Yes | Enable Vertex AI |
+| `CLAUDE_CODE_USE_FOUNDRY` | Yes | Yes | Enable Foundry |
+| `BASH_DEFAULT_TIMEOUT_MS` | Yes | Yes | Bash timeout |
+| `MAX_THINKING_TOKENS` | Yes | Yes | Extended thinking |
+| `CLAUDE_CONFIG_DIR` | Yes | Yes | Config directory |


### PR DESCRIPTION
Add comprehensive skill for the Claude Agent SDK with:
- Complete API reference for Python and TypeScript
- Feature parity comparison between Claude Code CLI and SDK
- Working code examples (quick_start, multi_turn, custom_tools)
- Best practices for agent development

Also add docs/claude-code-capabilities.md covering:
- Hooks, Subagents, Skills, Commands, Plugins/Marketplaces
- Configuration reference and file locations
- Quick reference guide for all extensibility features