### PR TITLE
docs: add actionable dev commands to CLAUDE.md files

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,10 +17,27 @@ A collection of agents, commands, and skills that extend Claude Code's capabilit
 
 ### Creating Plugins
 
-1. Create directory: `plugins/{name}/`
-2. Add `.claude-plugin/plugin.json` with metadata
-3. Add agents, commands, and/or skills
-4. Add entry to `.claude-plugin/marketplace.json`
+```bash
+# 1. Create plugin structure
+mkdir -p plugins/my-plugin/.claude-plugin
+mkdir -p plugins/my-plugin/{agents,commands,skills}
+
+# 2. Create plugin.json
+cat > plugins/my-plugin/.claude-plugin/plugin.json << 'EOF'
+{
+  "name": "my-plugin",
+  "version": "1.0.0",
+  "description": "What this plugin does"
+}
+EOF
+
+# 3. Add assets (agents, commands, skills)
+
+# 4. Register in marketplace
+# Edit .claude-plugin/marketplace.json to add entry
+```
+
+**Note**: Assets are copied, not symlinked. If sharing an asset across plugins, copy the file to each plugin that needs it.
 
 ### Key Files
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,22 @@ Project instructions have moved to modular rule files:
 
 Path-targeted rules load automatically when editing relevant files.
 
+## Development
+
+```bash
+# Validate marketplace.json syntax
+cat .claude-plugin/marketplace.json | jq .
+
+# Test plugin install locally (from repo root)
+claude /plugin install core --source ./plugins/core
+
+# Create a new plugin
+mkdir -p plugins/my-plugin/.claude-plugin
+mkdir -p plugins/my-plugin/{agents,commands,skills}
+```
+
+**Flat file architecture**: Plugins contain real files, not symlinks. Claude Code doesn't follow symlinks during plugin install, so assets must be copied into each plugin that needs them. See `docs/adr/0001-flat-file-architecture.md`.
+
 ## Key Files
 
 | File | Purpose |


### PR DESCRIPTION
## Summary

- Add development workflow commands to root `CLAUDE.md` (validate, test install, create plugin)
- Add concrete plugin creation example with copy-paste commands to `.claude/CLAUDE.md`
- Explain flat file architecture rationale inline (don't bury in ADR)

## Context

Ran a CLAUDE.md quality audit across all projects. This repo scored 72-73/100 - good but missing actionable dev commands. The homelab repo is the gold standard at 97/100 with every workflow having copy-paste commands.

## Test plan

- [ ] Verify `cat .claude-plugin/marketplace.json | jq .` works
- [ ] Verify plugin creation commands create valid structure
- [ ] Review that flat file explanation is clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)