### PR TITLE
chore: remove superpowers references from docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Workbench
 
-Hub registry for all personal Claude Code plugins and curated obra/superpowers forks.
+Hub registry for personal Claude Code plugins.
 
 ## Structure
 
@@ -10,34 +10,26 @@ Hub registry for all personal Claude Code plugins and curated obra/superpowers f
 └── docs/                   # Historical design docs
 ```
 
-## Plugins (17)
+## Plugins
 
-### Personal
+### Cadence Ecosystem
 
 | Plugin | Repo | Description |
 |---|---|---|
-| essentials | cameronsjo/essentials | Core workflow: brainstorming, worktrees, enforcement hooks, session management |
-| vibes | cameronsjo/vibes | Communication styles: hype, sass, roast, unhinged |
+| cadence | cameronsjo/cadence | Context management framework — four-tier workflow router, daily rhythm, session capture |
+| cadence-forge | cameronsjo/cadence-forge | Development workflow — logging, dependency vetting, release pipelines, diagrams |
+| cadence-mcp | cameronsjo/cadence-mcp | MCP server development patterns |
+| cadence-obsidian | cameronsjo/cadence-obsidian | Obsidian plugin development and vault workflows |
+| cadence-palette | cameronsjo/cadence-palette | Image generation toolkit for Gemini |
+| cadence-lab | cameronsjo/cadence-lab | Experimental — macOS integrations, tmux, MCP discovery |
+
+### Standalone
+
+| Plugin | Repo | Description |
+|---|---|---|
 | rules | cameronsjo/rules | 10 languages, security, quality, git, CI/CD, Docker, MCP, documentation |
-| dev-toolkit | cameronsjo/dev-toolkit | Logging agents, project checks, release pipelines |
-| mcp-toolkit | cameronsjo/mcp-toolkit | MCP server development patterns |
-| obsidian | cameronsjo/obsidian | Vault management, markdown, Bases, plugin dev |
-| homebridge-dev | cameronsjo/homebridge-dev | Homebridge plugin development |
-| image-gen-toolkit | cameronsjo/image-gen-toolkit | Gemini image generation |
-| homelab | cameronsjo/homelab | Homelab infrastructure context |
 | git-guardrails | cameronsjo/git-guardrails | Push/gh write guards, branch warnings, commit nudges |
-| project-onboard | cameronsjo/project-onboard | Onboarding skills for project portfolio |
-
-### Superpowers (obra forks)
-
-| Plugin | Repo | Description |
-|---|---|---|
-| superpowers | cameronsjo/superpowers | TDD, debugging, collaboration patterns |
-| superpowers-chrome | cameronsjo/superpowers-chrome | Chrome DevTools Protocol access |
-| superpowers-lab | cameronsjo/superpowers-lab | Experimental: tmux, MCP CLI, dedup |
-| superpowers-developing-for-claude-code | cameronsjo/superpowers-developing-for-claude-code | Plugin dev docs |
-| double-shot-latte | cameronsjo/double-shot-latte | Auto-continue |
-| elements-of-style | cameronsjo/the-elements-of-style | Strunk's writing guide |
+| pencil | cameronsjo/pencil | Design workflow for Pencil.dev — canvas design, .pen files |
 
 ## Plugin Repo Structure
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Workbench
 
-Hub registry for all personal Claude Code plugins and curated obra/superpowers forks.
+Hub registry for personal Claude Code plugins.
 
 ## Installation
 
@@ -9,40 +9,32 @@ Hub registry for all personal Claude Code plugins and curated obra/superpowers f
 /plugin marketplace add cameronsjo/workbench
 
 # Install what you need
-/plugin install essentials@cameronsjo
-/plugin install superpowers@cameronsjo
+/plugin install cadence@cameronsjo
+/plugin install rules@cameronsjo
 ```
 
 Or use the automated setup in `~/.claude/setup-marketplaces.sh`.
 
-## Plugins (17)
+## Plugins
 
-### Personal
+### Cadence Ecosystem
 
 | Plugin | Description |
 |---|---|
-| essentials | Core workflow: brainstorming, worktrees, enforcement hooks, session management |
-| vibes | Communication styles: hype, sass, roast, unhinged |
+| cadence | Context management framework — four-tier workflow router, daily rhythm, session capture |
+| cadence-forge | Development workflow — logging, dependency vetting, release pipelines, diagrams |
+| cadence-mcp | MCP server development patterns |
+| cadence-obsidian | Obsidian plugin development and vault workflows |
+| cadence-palette | Image generation toolkit for Gemini |
+| cadence-lab | Experimental — macOS integrations, tmux, MCP discovery |
+
+### Standalone
+
+| Plugin | Description |
+|---|---|
 | rules | 10 languages, security, quality, git, CI/CD, Docker, MCP, documentation |
-| dev-toolkit | Logging agents, project checks, release pipelines |
-| mcp-toolkit | MCP server development patterns |
-| obsidian | Vault management, markdown reference, Bases, plugin development |
-| homebridge-dev | Homebridge plugin development: HAP mappings, accessory patterns |
-| image-gen-toolkit | Image generation toolkit for Gemini |
-| homelab | Homelab infrastructure: Unraid, media stack, Docker services |
 | git-guardrails | Push/gh write guards, branch warnings, commit nudges |
-| project-onboard | Onboarding skills for project portfolio |
-
-### Superpowers (obra forks)
-
-| Plugin | Description |
-|---|---|
-| superpowers | Core skills: TDD, debugging, collaboration patterns |
-| superpowers-chrome | Chrome DevTools Protocol: skill mode + MCP mode |
-| superpowers-lab | Experimental: tmux, MCP discovery, duplicate detection |
-| superpowers-developing-for-claude-code | Plugin/skill/MCP development docs |
-| double-shot-latte | Auto-continues work instead of stopping to ask |
-| the-elements-of-style | Strunk's writing guidance (1918) |
+| pencil | Design workflow for Pencil.dev — canvas design, .pen files |
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- Remove "Superpowers (obra forks)" section from README and CLAUDE.md
- Remove retired plugins (essentials, vibes, dev-toolkit, mcp-toolkit, obsidian, homebridge-dev, image-gen-toolkit, homelab, project-onboard) from listings
- Replace with current inventory: cadence ecosystem (6 plugins) + standalone (3 plugins)
- Update install examples from `superpowers@cameronsjo` to `cadence@cameronsjo`

## Context

The marketplace.json no longer lists these plugins. This aligns the docs with reality.

Note: there's a stashed marketplace.json change on main that removes additional retired entries — that's separate from this PR.

## Test plan

- [ ] Verify plugin tables match what's in marketplace.json
- [ ] Verify no remaining "superpowers" references in docs (except ADR historical context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified Hub registry description for clarity.
  * Reorganized plugin catalog with new "Cadence Ecosystem" section featuring updated plugins.
  * Introduced "Standalone" section for select plugins.
  * Expanded Plugin Repo Structure documentation with detailed guidance and layout specifications.
  * Updated installation and setup references in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->