### PR TITLE
feat: register cadence-bootstrap plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,6 +15,14 @@
       }
     },
     {
+      "name": "cadence-bootstrap",
+      "description": "Bootstrap-only skills for cadence — initialization, marketplace setup, license selection, onboarding scaffolding, workspace tidying. Enable briefly during setup, then disable.",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/cameronsjo/cadence-bootstrap.git"
+      }
+    },
+    {
       "name": "cadence-forge",
       "description": "Development workflow tools — logging, dependency vetting, release pipelines, diagrams, and project checks",
       "source": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
     },
     {
       "name": "cadence-bootstrap",
-      "description": "Bootstrap-only skills for cadence — initialization, marketplace setup, license selection, onboarding scaffolding, workspace tidying. Enable briefly during setup, then disable.",
+      "description": "Bootstrap-only skills for cadence — initialization, marketplace setup, license selection. Enable briefly during setup, then disable.",
       "source": {
         "source": "url",
         "url": "https://github.com/cameronsjo/cadence-bootstrap.git"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Hub registry for personal Claude Code plugins.
 | Plugin | Repo | Description |
 |---|---|---|
 | cadence | cameronsjo/cadence | Context management framework — four-tier workflow router, daily rhythm, session capture |
+| cadence-bootstrap | cameronsjo/cadence-bootstrap | Bootstrap-only skills — init, marketplace setup, license selection, onboarding, tidying. Enable briefly during setup |
 | cadence-forge | cameronsjo/cadence-forge | Development workflow — logging, dependency vetting, release pipelines, diagrams |
 | cadence-mcp | cameronsjo/cadence-mcp | MCP server development patterns |
 | cadence-obsidian | cameronsjo/cadence-obsidian | Obsidian plugin development and vault workflows |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Hub registry for personal Claude Code plugins.
 | Plugin | Repo | Description |
 |---|---|---|
 | cadence | cameronsjo/cadence | Context management framework — four-tier workflow router, daily rhythm, session capture |
-| cadence-bootstrap | cameronsjo/cadence-bootstrap | Bootstrap-only skills — init, marketplace setup, license selection, onboarding, tidying. Enable briefly during setup |
+| cadence-bootstrap | cameronsjo/cadence-bootstrap | Bootstrap-only skills — init, marketplace setup, license selection. Enable briefly during setup |
 | cadence-forge | cameronsjo/cadence-forge | Development workflow — logging, dependency vetting, release pipelines, diagrams |
 | cadence-mcp | cameronsjo/cadence-mcp | MCP server development patterns |
 | cadence-obsidian | cameronsjo/cadence-obsidian | Obsidian plugin development and vault workflows |

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Or use the automated setup in `~/.claude/setup-marketplaces.sh`.
 | Plugin | Description |
 |---|---|
 | cadence | Context management framework — four-tier workflow router, daily rhythm, session capture |
+| cadence-bootstrap | Bootstrap-only skills — init, marketplace setup, license selection, onboarding, tidying. Enable briefly during setup |
 | cadence-forge | Development workflow — logging, dependency vetting, release pipelines, diagrams |
 | cadence-mcp | MCP server development patterns |
 | cadence-obsidian | Obsidian plugin development and vault workflows |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or use the automated setup in `~/.claude/setup-marketplaces.sh`.
 | Plugin | Description |
 |---|---|
 | cadence | Context management framework — four-tier workflow router, daily rhythm, session capture |
-| cadence-bootstrap | Bootstrap-only skills — init, marketplace setup, license selection, onboarding, tidying. Enable briefly during setup |
+| cadence-bootstrap | Bootstrap-only skills — init, marketplace setup, license selection. Enable briefly during setup |
 | cadence-forge | Development workflow — logging, dependency vetting, release pipelines, diagrams |
 | cadence-mcp | MCP server development patterns |
 | cadence-obsidian | Obsidian plugin development and vault workflows |


### PR DESCRIPTION
## Summary

- Adds `cadence-bootstrap` to `marketplace.json` so `claude plugin install cadence-bootstrap@workbench` resolves to the new repo at github.com/cameronsjo/cadence-bootstrap
- Updates README.md and CLAUDE.md plugin tables
- Plugin defaults to opt-in (no auto-enable in `setup-marketplaces.sh`)

## Why

`cadence-bootstrap` extracts 4 init-only skills from cadence core:
- `initializing-cadence`
- `install-cadence-hooks`
- `marketplace-setup`
- `choosing-license`

These fire <1× per project lifetime and were paying context budget cost in every session. Splitting them into an opt-in plugin keeps cadence core lean.

Two additional skills (`tidying-workspace`, `creating-onboarding-guide`) are being deleted entirely in the companion cadence cleanup PR — neither earns its keep.

## Sequencing

This PR registers the plugin. Companion PR in cadence (deletions of the 4 moved skills + 2 cadence-bootstrap-out-of-scope skills + 2 duplicate cleanups = 8 total deletions) lands AFTER this is merged so there's no skill-loss window for the 4 that survive.

## Test plan

- [ ] `CLAUDECODE= claude plugin marketplace update workbench` exits 0
- [ ] `claude plugin install cadence-bootstrap@workbench` succeeds
- [ ] In a fresh session with the plugin enabled, the 4 `cadence-bootstrap:` skills appear in the system reminder
- [ ] In a fresh session without the plugin enabled, skills do NOT appear (proves opt-in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)