### PR TITLE
feat(marketplace): register cadence-metrics

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -143,6 +143,14 @@
       }
     },
     {
+      "name": "cadence-metrics",
+      "description": "JSONL event logging for Claude Code sessions — cost-per-commit via PreToolUse/PostToolUse hooks. Pure data collection, no UI.",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/cameronsjo/cadence-metrics.git"
+      }
+    },
+    {
       "name": "artificer-design-system",
       "description": "Artificer — personal design system. AuDHD-optimized, dark-first, Jazz Age Deco palette. Tokens, live spec, framework adapters, and theme exports for Claude Code, Ghostty, VSCode, and Obsidian.",
       "source": {


### PR DESCRIPTION
## Summary

Registers `cadence-metrics` in the workbench marketplace. The plugin lives at [cameronsjo/cadence-metrics](https://github.com/cameronsjo/cadence-metrics) (currently private — will be made public after smoke test passes).

## What the plugin does

JSONL event logging for Claude Code sessions. v0: cost-per-commit. A PreToolUse:Bash hook snapshots HEAD when Claude is about to run `git commit`; a PostToolUse:Bash partner compares HEAD, scans the running transcript for new token usage since the previous commit, applies prices from `config/prices.json`, and appends one line to `~/.claude/metrics/commits.jsonl`.

Pure data collection. No slash commands, no UI.

## Test plan

- [ ] Merge this PR
- [ ] `claude plugin marketplace update workbench`
- [ ] `claude plugin install cadence-metrics@workbench`
- [ ] Make a real commit and verify a line appears in `~/.claude/metrics/commits.jsonl`
- [ ] Cost matches manual calculation against transcript tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new marketplace plugin for metrics and event logging, enabling enhanced tracking and cost monitoring for code sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cameronsjo/workbench/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->