### PR TITLE
feat: absorb attunements products into workbench marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -173,6 +173,70 @@
         "source": "url",
         "url": "https://github.com/cameronsjo/auditing-claude-md.git"
       }
+    },
+    {
+      "name": "bosun",
+      "description": "GitOps CLI for Docker Compose on bare metal — Helm for home",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/cameronsjo/bosun.git"
+      }
+    },
+    {
+      "name": "llm-council",
+      "description": "Multi-LLM deliberation web app with Council and Arena debate modes",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/cameronsjo/llm-council.git"
+      }
+    },
+    {
+      "name": "media-mcp",
+      "description": "MCP server enriching Obsidian vaults with book, movie, and TV metadata",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/cameronsjo/media-mcp.git"
+      }
+    },
+    {
+      "name": "mouse-mcp",
+      "description": "Disney parks data MCP server — attraction wait times, dining info, fuzzy search",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/cameronsjo/mouse-mcp.git"
+      }
+    },
+    {
+      "name": "obaass",
+      "description": "Headless Obsidian orchestrator — obsidi-headless, obsidi-backup, and obsidi-mcp via Docker Compose",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/cameronsjo/obaass.git"
+      }
+    },
+    {
+      "name": "obsidi-backup",
+      "description": "Vault backup sidecar — file watching, AI commit messages, restic cloud storage",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/cameronsjo/obsidi-backup.git"
+      }
+    },
+    {
+      "name": "obsidi-claude",
+      "description": "Obsidian plugin for chatting with Claude AI using the Anthropic Agent SDK",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/cameronsjo/obsidi-claude.git"
+      }
+    },
+    {
+      "name": "obsidi-mcp",
+      "description": "Obsidian plugin exposing 28+ vault tools via MCP server with CLI bridge",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/cameronsjo/obsidi-mcp.git"
+      }
     }
   ]
 }


### PR DESCRIPTION
Collapses the separate `attunements` product marketplace into `workbench`, so there is one marketplace to maintain. `attunements` is being archived.

## What changed
Appends 8 product plugins to the `workbench` catalog (21 → 29):

- `bosun` — GitOps CLI for Docker Compose on bare metal
- `llm-council` — Multi-LLM deliberation web app
- `media-mcp` — Obsidian book/movie/TV metadata MCP server
- `mouse-mcp` — Disney parks data MCP server
- `obaass` — Headless Obsidian orchestrator
- `obsidi-backup` — Vault backup sidecar
- `obsidi-claude` — Obsidian × Claude chat plugin
- `obsidi-mcp` — Obsidian vault tools MCP (→ `obsidi-mcp.git`)

## Deliberately excluded
- `artificer-design-system` — the canonical entry (→ `artificer-design-system.git`) already exists in this catalog; the attunements duplicate pointed at the older `artificer.git` and was dropped.
- `feedly-summarize-to-obsidian` — private repo; stays out of this public catalog.
- `claude-tty` — retired project; its repo has been archived.

## Naming note
The source marketplace listed this plugin under the stale name `obsidian-mcp`, but the repo's own `manifest.json`, `package.json`, and README already completed a rename to `obsidi-mcp` — only the Claude Code plugin identity lagged. This catalog uses `obsidi-mcp`; a companion PR to `cameronsjo/obsidi-mcp` finishes the rename in the plugin's `plugin.json` and skill frontmatter so the marketplace name matches the plugin's declared name.

## Verification
- Valid JSON, 29 plugins, no duplicate names.
- The 8 migrated names present; `feedly-summarize-to-obsidian`, `claude-tty`, and stale `obsidian-mcp` absent.
- `artificer-design-system` appears exactly once → `artificer-design-system.git`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)