### PR TITLE
docs: sync README, CONTRIBUTING, CLAUDE.md, CHANGELOG to registry reality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,41 +1,31 @@
 # Changelog
 
-## 1.0.0 (2025-12-01)
+All notable changes to the workbench marketplace registry are documented here.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Plugins carry no version numbers — the marketplace uses SHA-based cache invalidation
+(see `docs/adr/0001-plugin-cache-versioning.md`), so this log tracks registry changes
+rather than tagged releases.
 
-### Features
+## [Unreleased]
 
-* add deep-research skill and essentials plugin ([2d93861](https://github.com/cameronsjo/claude-marketplace/commit/2d93861231a22020d8f71c9adfc438ce6ca21f87))
-* add marketplace-meta plugin for self-improvement feedback ([1bac77c](https://github.com/cameronsjo/claude-marketplace/commit/1bac77cb182f09feca802dd76ada34596ef7e25a))
-* add obsidian-plugin-dev plugin for Obsidian plugin development ([a279f03](https://github.com/cameronsjo/claude-marketplace/commit/a279f035a7549a0a2ad5f9d461cec350f8c8ecee))
-* add plugin-builder CLI and registry-based architecture ([3195a00](https://github.com/cameronsjo/claude-marketplace/commit/3195a00c47e8716a0e491887a9280bccb0be37ff))
-* add sass, hype, and roast communication commands ([f45ed01](https://github.com/cameronsjo/claude-marketplace/commit/f45ed01cef2c5af692462247fa16c41527392a65))
-* **claude-code-web:** add plugin for Claude Code on the web support ([#1](https://github.com/cameronsjo/claude-marketplace/issues/1)) ([cadc1c4](https://github.com/cameronsjo/claude-marketplace/commit/cadc1c4907c19d0a32ef19e76669111cb072baa6))
-* **cli:** add dashboard, usage analytics, and search to plugin-builder ([ff9ba9f](https://github.com/cameronsjo/claude-marketplace/commit/ff9ba9f7ead151773232add555ff254f1411bcd1))
-* **cli:** add TUI for plugin-builder and update scripts ([9ad0ac3](https://github.com/cameronsjo/claude-marketplace/commit/9ad0ac35dc5cba8cfcf7e689e58f0d2c7a1ff8cc))
-* **commands:** add roadmap management commands ([f66cea0](https://github.com/cameronsjo/claude-marketplace/commit/f66cea0843bb5171335075bf63daff4acc2d191b))
-* initial marketplace with 12 plugins ([f956dcd](https://github.com/cameronsjo/claude-marketplace/commit/f956dcdf2dd112a7370c835612c881816bd846d0))
-* **mcp:** add comprehensive MCP skill updates and tools-as-code pattern ([5cb41d6](https://github.com/cameronsjo/claude-marketplace/commit/5cb41d6a08d5b733e14596b8b2ba0787f9dfc902))
-* migrate user-level assets to marketplace registry ([f3c7f46](https://github.com/cameronsjo/claude-marketplace/commit/f3c7f4624cda9771e4753339de92d0213e364d17))
-* **obsidian:** add recipes, references, and workflows ([3f47b84](https://github.com/cameronsjo/claude-marketplace/commit/3f47b847cb8cfe9d62af045d949177570541990a))
-* **roadmap:** add roadmap docs structure and management commands ([9dd9e54](https://github.com/cameronsjo/claude-marketplace/commit/9dd9e54bad28190988f7d154894f18c20f3c87e1))
-* sync 2025 toolkit updates from ~/.claude ([50be267](https://github.com/cameronsjo/claude-marketplace/commit/50be2675f970628009a0eea52c372ffe2eb8c9cd))
-* **tui:** add preset group buttons for quick selection ([9be5b56](https://github.com/cameronsjo/claude-marketplace/commit/9be5b56dbbb645e827d7894a119888797094dc36))
-* **tui:** add/remove assets via modal dialogs ([a8f99c2](https://github.com/cameronsjo/claude-marketplace/commit/a8f99c258482637a610e29e2a2aee5c5bf7be32d))
-* **tui:** multiselect for add/remove assets with grouping ([802caa3](https://github.com/cameronsjo/claude-marketplace/commit/802caa32c93f57fb6f4b9ffcf159a7d444958800))
-* **versioning:** add Release Please automation for semantic versioning ([ef17d0f](https://github.com/cameronsjo/claude-marketplace/commit/ef17d0fad4c3db33e9d90b4cc4e0f1a345197872))
+### Added
 
+- Absorbed the attunements products as standalone `url` entries: `bosun`, `llm-council`,
+  `media-mcp`, `mouse-mcp`, `obaass`, `obsidi-backup`, `obsidi-claude`, `obsidi-mcp` (#44).
 
-### Bug Fixes
+### Changed
 
-* **plugin-builder:** sync marketplace.json with plugin renames and bump to v1.1.0 ([1ea6947](https://github.com/cameronsjo/claude-marketplace/commit/1ea69478f63060a9e51844039e4dc4e4204e952f))
-* rename web plugin to cc-web for clarity ([8d2339b](https://github.com/cameronsjo/claude-marketplace/commit/8d2339b8bc27e41508e2dbc530ab3cab8d0ea0df))
-* **tui:** fix invalid BINDINGS format (max 3 elements per tuple) ([ba45f1d](https://github.com/cameronsjo/claude-marketplace/commit/ba45f1d4a9aa29e3260a47819184334b628596fa))
-* **tui:** fix screen navigation to not use switch_screen ([d04fa42](https://github.com/cameronsjo/claude-marketplace/commit/d04fa4214c953e1eeaf640db100e618d87dba8df))
-* **tui:** use correct AssetType enum names (COMMAND not COMMANDS) ([fc3e052](https://github.com/cameronsjo/claude-marketplace/commit/fc3e052595fe9cd96a61158db7c773aef6aafd50))
-* **tui:** use hex colors instead of undefined CSS variables in modals ([afb7a30](https://github.com/cameronsjo/claude-marketplace/commit/afb7a30f7b7940d049b8f8306cb67101c03c9bad))
-* **tui:** use plain tracebacks instead of rich formatting ([a2bb099](https://github.com/cameronsjo/claude-marketplace/commit/a2bb09971c64b6dc8cbcb43f2e3ee14529a28d7d))
-* **tui:** use relative imports for package portability ([985ecdc](https://github.com/cameronsjo/claude-marketplace/commit/985ecdcfe353becb4212ed57fb54316c8f98f962))
-* **tui:** use switch_screen to avoid popping last screen ([5328af1](https://github.com/cameronsjo/claude-marketplace/commit/5328af13f9b81b14c8138a3f7c9788fc5051ce63))
-* **tui:** use unique IDs for plugin list items to avoid duplicates ([a445ff8](https://github.com/cameronsjo/claude-marketplace/commit/a445ff81ce3208ed1367f0e2193aae645ac4a4a1))
-* update owner info in marketplace.json ([b11794a](https://github.com/cameronsjo/claude-marketplace/commit/b11794aee701baa6184def58231a1c047694b098))
+- Re-pointed the 12 cadence-ecosystem plugins to the `cameronsjo/cadence` monorepo via
+  `git-subdir` sources, replacing their standalone `url` sources (#43).
+
+### Removed
+
+- Dropped `cadence-lab`, which split off into its own marketplace (#43).
+
+---
+
+History prior to this entry was inherited from the predecessor `claude-marketplace`
+repository and did not reflect workbench's contents; it has been reset. Run
+`scripts/changelog-gen.sh` to regenerate a fuller changelog from conventional commits
+if a more detailed history is wanted.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Hub registry for personal Claude Code plugins.
 
 ## Structure
 
-```
+```text
 ├── marketplace.json        # Plugin registry (url + git-subdir sources)
 ├── README.md               # Plugin directory with install instructions
 └── docs/                   # Historical design docs
@@ -40,7 +40,7 @@ Domain satellites and shared infrastructure:
 
 Each plugin follows:
 
-```
+```text
 repo-root/                # or plugins/<name>/ in the cadence monorepo
 ├── .claude-plugin/
 │   ├── marketplace.json  # Standalone repos only — declares it as its own marketplace

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Hub registry for personal Claude Code plugins.
 ## Structure
 
 ```
-├── marketplace.json        # Plugin registry (all plugins via URL sources)
+├── marketplace.json        # Plugin registry (url + git-subdir sources)
 ├── README.md               # Plugin directory with install instructions
 └── docs/                   # Historical design docs
 ```
@@ -18,38 +18,43 @@ Three primary rhythms map to three primary plugins:
 
 | Plugin | Repo | Rhythm | Description |
 |---|---|---|---|
-| cadence | cameronsjo/cadence | always-on | Everyday session-agnostic methodology — four-tier router, daily rhythm, capture, dispatch, everyday tuning |
-| cadence-forge | cameronsjo/cadence-forge | dev sessions | Dev workflow — debugging, testing, polish, logging, review, dependency vetting |
-| cadence-groundwork | cameronsjo/cadence-groundwork | enable, run, disable | Episodic ground-breaking — scaffolding archetypes, license selection, marketplace and hooks setup, CI/CD, plugin/rules authoring |
+| cadence | cameronsjo/cadence → plugins/cadence | always-on | Everyday session-agnostic methodology — four-tier router, daily rhythm, capture, dispatch, everyday tuning |
+| cadence-forge | cameronsjo/cadence → plugins/cadence-forge | dev sessions | Dev workflow — debugging, testing, polish, logging, review, dependency vetting |
+| cadence-groundwork | cameronsjo/cadence → plugins/cadence-groundwork | enable, run, disable | Episodic ground-breaking — scaffolding archetypes, license selection, marketplace and hooks setup, CI/CD, plugin/rules authoring |
 
 Domain satellites and shared infrastructure:
 
 | Plugin | Repo | Description |
 |---|---|---|
-| cadence-voice | cameronsjo/cadence-voice | Communication and presence — prose craft, AI pattern detection, brand, data storytelling, conflict resolution |
-| cadence-mcp | cameronsjo/cadence-mcp | MCP server development patterns |
-| cadence-obsidian | cameronsjo/cadence-obsidian | Obsidian plugin development and vault workflows |
-| cadence-palette | cameronsjo/cadence-palette | Image generation toolkit for Gemini |
-| cadence-lab | cameronsjo/cadence-lab | Experimental — macOS integrations, tmux, MCP discovery |
-| cadence-rules | cameronsjo/cadence-rules | 10 languages, security, quality, git, CI/CD, Docker, MCP, documentation |
-| cadence-guardrails | cameronsjo/cadence-guardrails | Push/gh write guards, branch warnings, commit nudges |
+| cadence-voice | cameronsjo/cadence → plugins/cadence-voice | Communication and presence — prose craft, AI pattern detection, brand, data storytelling, conflict resolution |
+| cadence-mcp | cameronsjo/cadence → plugins/cadence-mcp | MCP server development patterns |
+| cadence-obsidian | cameronsjo/cadence → plugins/cadence-obsidian | Obsidian plugin development and vault workflows |
+| cadence-palette | cameronsjo/cadence → plugins/cadence-palette | Image generation toolkit for Gemini |
+| cadence-discovery | cameronsjo/cadence → plugins/cadence-discovery | Feature ideation pipeline — usage-grounded discovery producing one attune-ready feature |
+| cadence-canon | cameronsjo/cadence → plugins/cadence-canon | Multi-session coordination — session identity, peer disclosure, lane warnings |
+| cadence-metrics | cameronsjo/cadence → plugins/cadence-metrics | JSONL event logging — cost-per-commit via Pre/PostToolUse hooks |
+| cadence-rules | cameronsjo/cadence → plugins/cadence-rules | 10 languages, security, quality, git, CI/CD, Docker, MCP, documentation |
+| cadence-guardrails | cameronsjo/cadence → plugins/cadence-guardrails | Push/gh write guards, branch warnings, commit nudges |
 
 ## Plugin Repo Structure
 
-Each plugin repo follows:
+Each plugin follows:
 
 ```
-repo-root/
+repo-root/                # or plugins/<name>/ in the cadence monorepo
 ├── .claude-plugin/
-│   ├── marketplace.json    # Declares repo as a standalone marketplace
-│   └── plugin.json         # Plugin metadata
-├── commands/               # Slash commands (.md)
-├── agents/                 # Subagents (.md)
-├── skills/                 # Skills with SKILL.md
+│   ├── marketplace.json  # Standalone repos only — declares it as its own marketplace
+│   └── plugin.json       # Plugin metadata
+├── commands/              # Slash commands (.md)
+├── agents/                # Subagents (.md)
+├── skills/                # Skills with SKILL.md
 ├── README.md
 ├── LICENSE
 └── .gitignore
 ```
+
+A `git-subdir` plugin (the 12 cadence-ecosystem entries) has no per-plugin `marketplace.json` — that
+file exists once, at the `cameronsjo/cadence` repo root.
 
 ### Skill Path Resolution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,42 +1,92 @@
 # Contributing
 
-Guide for adding plugins to the Claude Marketplace.
+Guide for adding a plugin to the workbench marketplace.
 
-## Quick Start
+## The model
 
-```bash
-# 1. Clone
-git clone https://github.com/cameronsjo/claude-marketplace.git
-cd claude-marketplace
+Workbench is a **registry**, not a source monorepo. It ships no plugin code of its own — its
+`.claude-plugin/marketplace.json` is a list of entries, each pointing at a plugin that lives
+**somewhere else**:
 
-# 2. Create plugin
-mkdir -p src/my-plugin/{.claude-plugin,commands}
+- A **standalone repo** — the plugin owns its own GitHub repository (`url` source).
+- A **monorepo subdir** — the plugin lives under `plugins/<name>/` of a shared repo, currently
+  `cameronsjo/cadence` (`git-subdir` source).
 
-# 3. Add plugin.json, commands, README
-# 4. Register in index.json
-# 5. Submit PR
+There is no `src/`, no `index.json`, and no version numbers. See
+[Versioning](#versioning) below.
+
+## Adding a plugin
+
+### 1. Publish the plugin
+
+The plugin lives in its own repo (or a `plugins/<name>/` subdir of a monorepo) with a
+`.claude-plugin/plugin.json`. See [Plugin repo structure](#plugin-repo-structure).
+
+### 2. Register it in `marketplace.json`
+
+Add one entry to the `plugins` array in `.claude-plugin/marketplace.json`. Pick the source shape
+that matches where the plugin lives.
+
+**Standalone repo — `url` source:**
+
+```json
+{
+  "name": "my-plugin",
+  "description": "Brief description shown in /plugin discover",
+  "source": {
+    "source": "url",
+    "url": "https://github.com/cameronsjo/my-plugin.git"
+  }
+}
 ```
 
-## Plugin Structure
+**Monorepo subdir — `git-subdir` source:**
+
+```json
+{
+  "name": "my-plugin",
+  "description": "Brief description shown in /plugin discover",
+  "source": {
+    "source": "git-subdir",
+    "url": "https://github.com/cameronsjo/cadence.git",
+    "path": "plugins/my-plugin"
+  }
+}
+```
+
+### 3. Add a `README.md` row
+
+Add the plugin to the appropriate table in `README.md` — the Cadence Ecosystem table for a
+`cameronsjo/cadence` subdir, or the Standalone table for its own repo.
+
+### 4. Open a PR
+
+Submit against `cameronsjo/workbench`.
+
+## Plugin repo structure
+
+Each plugin follows:
 
 ```
-src/my-plugin/
+repo-root/                    # or plugins/<name>/ in a monorepo
 ├── .claude-plugin/
-│   └── plugin.json      # Required: metadata
-├── README.md            # Required: documentation
-├── commands/            # Slash commands
+│   └── plugin.json           # Required: metadata
+├── commands/                 # Slash commands (.md)
 │   └── my-command.md
-└── agents/              # Subagents (optional)
-    └── my-agent.md
+├── agents/                   # Subagents (.md, optional)
+│   └── my-agent.md
+├── skills/                   # Skills with SKILL.md (optional)
+│   └── my-skill/SKILL.md
+├── README.md                 # Required: documentation
+└── LICENSE
 ```
 
-## plugin.json
+### plugin.json
 
 ```json
 {
   "name": "my-plugin",
   "description": "Brief description for /plugin discover",
-  "version": "1.0.0",
   "author": {
     "name": "your-github-username"
   },
@@ -50,13 +100,14 @@ src/my-plugin/
 |-------|----------|-------------|
 | `name` | Yes | Plugin identifier (kebab-case) |
 | `description` | Yes | One-line description |
-| `version` | Yes | Semver (auto-updated on release) |
 | `author.name` | Yes | GitHub username or name |
 | `keywords` | No | Search/discovery terms |
 
-## Command Format
+No `version` field — see [Versioning](#versioning).
 
-`src/my-plugin/commands/my-command.md`:
+## Command format
+
+`commands/my-command.md`:
 
 ```yaml
 ---
@@ -92,9 +143,9 @@ $ARGUMENTS
 - Use `allowed-tools` to limit scope (security)
 - Use `disable-model-invocation: true` for commands that modify Claude's behavior rather than spawning agents
 
-## Agent Format
+## Agent format
 
-`src/my-plugin/agents/my-agent.md`:
+`agents/my-agent.md`:
 
 ```yaml
 ---
@@ -132,60 +183,29 @@ What this agent does and how.
 | `color` | No | Terminal color for output |
 | `tools` | No | Available tools (defaults to all) |
 
-## Registering in index.json
+## PR checklist
 
-Add your plugin to the `plugins` array:
-
-```json
-{
-  "plugins": [
-    {
-      "name": "my-plugin",
-      "version": "1.0.0",
-      "path": "./src/my-plugin",
-      "description": "Same as plugin.json description"
-    }
-  ]
-}
-```
-
-## PR Checklist
-
-- [ ] Plugin directory in `src/`
-- [ ] Valid `plugin.json` with name, description, version
-- [ ] README.md documenting commands/agents
+- [ ] Plugin published with a valid `.claude-plugin/plugin.json` (name, description, author)
+- [ ] README.md documenting commands/agents/skills
 - [ ] All commands have `description` frontmatter
 - [ ] All agents have `name` and `description` frontmatter
-- [ ] Entry added to `index.json`
-- [ ] CI passes (validates structure automatically)
+- [ ] Entry added to `marketplace.json` (`url` or `git-subdir` source)
+- [ ] Row added to the `README.md` table
 
 ## Versioning
 
-Don't manually update versions. On merge to main:
+Plugins carry **no `version` field**. Workbench uses SHA-based cache invalidation — Claude Code
+re-pins each installed plugin to its latest pushed commit at session start, so a version number
+would be redundant bookkeeping. This is a deliberate design decision; see
+`docs/adr/0001-plugin-cache-versioning.md`.
 
-1. Conventional commit determines bump type
-2. All plugin versions sync automatically
-3. Git tag + GitHub release created
+## Testing locally
 
-**Commit prefixes:**
-
-| Prefix | Version Bump |
-|--------|--------------|
-| `feat:` | Minor (0.1.0 → 0.2.0) |
-| `fix:` | Patch (0.1.0 → 0.1.1) |
-| `feat!:` | Major (0.1.0 → 1.0.0) |
-| `chore:`, `docs:`, `refactor:` | No bump |
-
-## Testing Locally
-
-```bash
-# Install from local path
-/plugin install /path/to/claude-marketplace/src/my-plugin
-
-# Or symlink for development
-ln -s /path/to/claude-marketplace/src/my-plugin ~/.claude/plugins/my-plugin
-```
+For instant edit propagation on the dev machine, point the marketplace at a local checkout with a
+path override in `~/.claude/setup-marketplaces.sh`. Edits to the local plugin source then take
+effect without a push/re-pin cycle. Remove the override to fall back to the published source.
 
 ## Questions?
 
-Open an issue or check existing plugins for examples.
+Open an issue on `cameronsjo/claude-configurations` (the ecosystem tracker) or check existing
+entries in `marketplace.json` for examples.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ Submit against `cameronsjo/workbench`.
 
 Each plugin follows:
 
-```
+```text
 repo-root/                    # or plugins/<name>/ in a monorepo
 ├── .claude-plugin/
 │   └── plugin.json           # Required: metadata

--- a/README.md
+++ b/README.md
@@ -21,27 +21,52 @@ Or use the automated setup in `~/.claude/setup-marketplaces.sh`.
 
 | Plugin | Description | Rhythm |
 |---|---|---|
-| cadence | Everyday session-agnostic methodology — four-tier router, daily rhythm, capture, dispatch, everyday tuning | always-on |
-| cadence-forge | Dev workflow during a session — debugging, testing, polish, logging, review, dependency vetting | dev sessions |
-| cadence-groundwork | Episodic ground-breaking — scaffolding archetypes, license selection, marketplace and hooks setup, CI/CD pipeline setup, plugin and rules authoring | enable, run, disable |
-| cadence-voice | Communication and presence — prose craft, AI pattern detection, personal brand, data storytelling, conflict resolution | episodic |
-| cadence-mcp | MCP server development patterns | episodic |
+| cadence | Context management framework — four-tier router, daily rhythm, capture, dispatch | always-on |
+| cadence-forge | Dev workflow — logging, dependency vetting, release pipelines, diagrams, checks | dev sessions |
+| cadence-groundwork | Episodic ground-breaking — scaffolding, licenses, marketplace/hooks/CI setup, authoring | enable, run, disable |
+| cadence-voice | Communication and presence — prose craft, AI pattern detection, brand, conflict resolution | episodic |
+| cadence-mcp | MCP server development — architecture patterns, tools-as-code | episodic |
 | cadence-obsidian | Obsidian plugin development and vault workflows | episodic |
-| cadence-palette | Image generation toolkit for Gemini | episodic |
-| cadence-lab | Experimental — macOS integrations, tmux, MCP discovery | as needed |
-| cadence-rules | 10 languages, security, quality, git, CI/CD, Docker, MCP, documentation | always-on |
+| cadence-palette | Image generation toolkit — Gemini prompt engineering, composition specs | episodic |
+| cadence-discovery | Feature ideation pipeline — usage-grounded discovery producing one attune-ready feature | episodic |
+| cadence-canon | Multi-session coordination — session identity, peer disclosure, lane warnings | always-on |
+| cadence-metrics | JSONL event logging — cost-per-commit via Pre/PostToolUse hooks | always-on |
+| cadence-rules | Language standards, security, quality, git, CI/CD, Docker, MCP, documentation | always-on |
 | cadence-guardrails | Push/gh write guards, branch warnings, commit nudges | always-on |
 
 ### Standalone
 
 | Plugin | Description |
 |---|---|
+| homebridge-dev | Homebridge plugin development — HAP mappings, accessory patterns, debugging |
+| homelab | Homelab infrastructure context — Unraid server, media stack, Docker services |
+| superpowers-chrome | Direct Chrome DevTools Protocol access — skill mode + MCP mode, zero dependencies |
+| superpowers-developing-for-claude-code | Skills and docs for developing Claude Code plugins, skills, and MCP servers |
+| double-shot-latte | Auto-continues Claude Code work instead of stopping to ask permission |
 | agent-pool | Expert pool — mixture-of-experts routing with filesystem mail and contracts |
 | artificer-design-system | Artificer design system — tokens, live spec, framework adapters, themes for Claude Code/Ghostty/VSCode/Obsidian |
+| auditing-claude-md | Audit CLAUDE.md and the context stack — shouting, derivable content, wrong-layer placement, token bloat |
+| bosun | GitOps CLI for Docker Compose on bare metal — Helm for home |
+| llm-council | Multi-LLM deliberation web app with Council and Arena debate modes |
+| media-mcp | MCP server enriching Obsidian vaults with book, movie, and TV metadata |
+| mouse-mcp | Disney parks data MCP server — attraction wait times, dining info, fuzzy search |
+| obaass | Headless Obsidian orchestrator — obsidi-headless, obsidi-backup, and obsidi-mcp via Docker Compose |
+| obsidi-backup | Vault backup sidecar — file watching, AI commit messages, restic cloud storage |
+| obsidi-claude | Obsidian plugin for chatting with Claude AI using the Anthropic Agent SDK |
+| obsidi-mcp | Obsidian plugin exposing 28+ vault tools via MCP server with CLI bridge |
 
 ## Architecture
 
-Each plugin lives in its own GitHub repo. This registry's `marketplace.json` references them via URL sources. On the dev machine, local path overrides in `setup-marketplaces.sh` provide instant edit propagation.
+This repo is a **registry**, not a source monorepo — `marketplace.json` points at plugins that live
+elsewhere, via two source models:
+
+- The 12 cadence-ecosystem plugins live in the **`cameronsjo/cadence` monorepo** under
+  `plugins/<name>/`, referenced with `git-subdir` sources.
+- Standalone plugins each live in their own GitHub repo, referenced with `url` sources.
+
+No plugin carries a `version` field — the marketplace uses SHA-based cache invalidation, so each
+pushed commit re-pins at session start (see `docs/adr/0001-plugin-cache-versioning.md`). On the dev
+machine, local path overrides in `setup-marketplaces.sh` provide instant edit propagation.
 
 ## License
 


### PR DESCRIPTION
## What

`marketplace.json` was brought current during the monorepo consolidation (#43) and the attunements absorption (#44), but the surrounding docs never followed — they still described a pre-monorepo world, and `CONTRIBUTING.md` was an unedited template inherited from the predecessor `claude-marketplace` repo. This makes README, CONTRIBUTING, CLAUDE.md, and CHANGELOG faithful mirrors of the already-correct registry.

**`marketplace.json` is unchanged — it was already correct.** Source of truth throughout.

## Changes

- **README** — Cadence Ecosystem table rebuilt to the 12 registered plugins (drops `cadence-lab`, which split into its own marketplace; adds `cadence-canon`, `cadence-discovery`, `cadence-metrics`). Standalone table now lists all 16 `url` plugins. The Architecture section replaces the false "each plugin in its own repo via URL" line with the real two-source model — `git-subdir` for the 12 cadence plugins living under `cameronsjo/cadence` `plugins/<name>`, `url` for standalone repos — and cites ADR-0001 for SHA-based (versionless) cache invalidation.
- **CONTRIBUTING** — replaced the inherited `claude-marketplace` template (`src/`, `index.json`, Release Please auto-versioning — none of which workbench uses) with the actual registry flow: publish the plugin → add a `url` or `git-subdir` entry to `marketplace.json` (both JSON shapes shown) → add a README row → PR. No version fields (ADR-0001). Kept the still-accurate plugin repo layout and command/agent frontmatter tables; swapped "Testing Locally" for the real `setup-marketplaces.sh` local-override approach.
- **CLAUDE.md** — same monorepo sync; the `Repo` column now points at `cameronsjo/cadence → plugins/<name>` for the 12. Also corrected the "Plugin Repo Structure" tree, which post-monorepo was stale: `git-subdir` plugins carry no per-plugin `marketplace.json` (that file exists once, at the `cameronsjo/cadence` repo root) — the diagram now marks it "Standalone repos only" and adds a clarifying line. "Skill Path Resolution" left as-is (still accurate).
- **CHANGELOG** — the prior file was the predecessor `claude-marketplace` changelog: its commit SHAs exist as dangling objects but are **not** ancestors of this repo's HEAD (which starts fresh at `Initial commit`, 2026-01-31), so the history was foreign, not a rename lineage. Reset to a Keep-a-Changelog scaffold with an `[Unreleased]` capturing #43/#44. `scripts/changelog-gen.sh` can regenerate a fuller history from conventional commits if wanted.

## Parity (verified against `marketplace.json`)

- README Cadence table = the 12 `git-subdir` entries, exact match
- README Standalone table = the 16 `url` entries, exact match
- `cadence-lab` and `claude-marketplace` appear nowhere in README or CLAUDE.md
- `git diff --stat` touches only the 4 doc files — never `marketplace.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog, README, and contribution guide to match the current registry-based marketplace workflow.
  * Clarified how `marketplace.json` sources work (URL vs `git-subdir`) and documented SHA-based cache invalidation plus local development overrides.
  * Refreshed Cadence ecosystem plugin mappings and expanded/updated standalone plugin listings; removed the former cadence-lab references.
  * Updated repo structure guidance and plugin contribution steps; adjusted `plugin.json` schema documentation and versioning expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->