### PR TITLE
feat: register cadence-kanban plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -70,6 +70,15 @@
       }
     },
     {
+      "name": "cadence-kanban",
+      "description": "Flux kanban board integration for cadence — durable, cross-machine continuation as board cards, with a one-command board bootstrap",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/cameronsjo/cadence.git",
+        "path": "plugins/cadence-kanban"
+      }
+    },
+    {
       "name": "cadence-rules",
       "description": "How to work with code — language standards, security, quality, git, CI/CD, Docker, MCP, documentation",
       "source": {


### PR DESCRIPTION
Register the new **cadence-kanban** satellite (git-subdir of the cadence monorepo, `plugins/cadence-kanban`) in the workbench registry. Mirrors the `cadence-canon` entry.

Pairs with cameronsjo/cadence#320 (the extraction). **Merge that PR first** so the `plugins/cadence-kanban` subdir exists at the pinned git-subdir path before workbench resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)