### PR TITLE
chore: gitignore .claude/intros/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ node_modules/
 # Logs
 *.log
 .worktrees/
+
+# session intros are gitignored — never committed
+.claude/intros/


### PR DESCRIPTION
## gitignore `.claude/intros/`

Session intros are ephemeral kickoff prompts, gitignored across the cadence ecosystem — they should
never ride into a committed tree. Adds the ignore to match the meta-repo and cadence conventions.

Part of the ecosystem-wide doc/artifact placement pass (companion PRs in `cadence` and
`claude-configurations`).
